### PR TITLE
Add instruction to README to ensure mkosi cache directory exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ For more information about this repository, see [the Flashbots collective post](
    # On other systems, download via package manager or use Docker approach below
    ```
 
+4. Ensure mkosi cache directory exists:
+   ```bash
+   mkdir -p ~/.cache/mkosi
+   ```
+
 ### Building Images
 
 1. **Enter the development environment**:


### PR DESCRIPTION
When following the build instruction in the README on a clean install of Debian, i got an error if the mkosi cache directory did not exist.