### PR TITLE
Add verification scripts and verification dockerfile

### DIFF
--- a/verify/Dockerfile
+++ b/verify/Dockerfile
@@ -1,0 +1,28 @@
+FROM debian:trixie
+
+# Update and install all required packages
+RUN apt-get update && apt-get install -y \
+    python3-requests \
+    python3-debian \
+    equivs \
+    mmdebstrap \
+    sbuild \
+    apt-utils \
+    wget \
+    vim \
+    curl \
+    gnupg \
+    devscripts \
+    dpkg-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN echo "root:100000:65536" >> /etc/subuid && \
+    echo "root:100000:65536" >> /etc/subgid
+
+COPY verify.py /usr/local/bin/verify.py
+RUN chmod +x /usr/local/bin/verify.py
+
+WORKDIR /workspace
+
+ENTRYPOINT ["python3", "/usr/local/bin/verify.py"]

--- a/verify/verify-lite.py
+++ b/verify/verify-lite.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+import json
+import csv
+import requests
+from pathlib import Path
+from collections import defaultdict
+
+def fetch_status(arch):
+    """Fetch package reproducibility status from Debian CI."""
+    url = f"https://{arch}.reproduce.debian.net/api/v0/pkgs/list"
+    return {(p['name'], p['architecture']): p for p in requests.get(url).json()}
+
+def main():
+    # Load manifest
+    manifest = next(Path("build").glob("*.manifest"))
+    with open(manifest) as f:
+        packages = [p for p in json.load(f)["packages"] if p["type"] == "deb"]
+    
+    # Fetch status from Debian CI
+    print("Fetching reproducibility status from Debian CI...")
+    amd64_status = fetch_status("amd64")
+    all_status = fetch_status("all")
+    status_data = {**amd64_status, **all_status}
+    
+    # Analyze packages
+    results = []
+    stats = defaultdict(int)
+    
+    for pkg in packages:
+        name, version, arch = pkg["name"], pkg["version"], pkg["architecture"]
+        
+        # Look up status
+        ci_pkg = status_data.get((name, arch))
+        
+        if not ci_pkg:
+            status = "UNKNOWN"
+            ci_version = "N/A"
+        else:
+            status = ci_pkg["status"]
+            ci_version = ci_pkg["version"]
+        
+        version_match = version == ci_version
+        
+        results.append({
+            "name": name,
+            "architecture": arch,
+            "version": version,
+            "ci_version": ci_version,
+            "status": status,
+            "version_match": version_match
+        })
+        
+        stats[status] += 1
+        if not version_match and ci_pkg:
+            stats["VERSION_MISMATCH"] += 1
+    
+    # Write CSV report
+    with open("build/debian-ci-report.csv", 'w', newline='') as f:
+        writer = csv.DictWriter(f, ["name", "architecture", "version", "ci_version", "status", "version_match"])
+        writer.writeheader()
+        writer.writerows(results)
+    
+    # Print summary
+    total = len(results)
+    print(f"\n{'='*50}")
+    print(f"Total packages: {total}")
+    for status, count in sorted(stats.items()):
+        print(f"{status}: {count} ({count/total*100:.1f}%)")
+    
+    print(f"\nReport saved to: build/debian-ci-report.csv")
+
+if __name__ == "__main__":
+    main()

--- a/verify/verify.py
+++ b/verify/verify.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+import json
+import subprocess
+import csv
+import hashlib
+from pathlib import Path
+import tempfile
+import shutil
+
+def sha256(filepath):
+    """Calculate SHA256 hash of a file."""
+    h = hashlib.sha256()
+    with open(filepath, "rb") as f:
+        while chunk := f.read(8192):
+            h.update(chunk)
+    return h.hexdigest()
+
+def verify_package(pkg, work_dir, cache_dir):
+    """Verify a single package's reproducibility."""
+    name, version, arch = pkg["name"], pkg["version"], pkg["architecture"]
+    arch = "all" if arch == "all" else "amd64"
+    
+    # Download buildinfo
+    folder = name[:4] if name.startswith("lib") else name[0]
+    buildinfo = f"{name}_{version}_{arch}.buildinfo"
+    url = f"https://buildinfos.debian.net/buildinfo-pool/{folder}/{name}/{buildinfo}"
+    
+    if subprocess.run(["wget", "-q", url], cwd=work_dir).returncode != 0:
+        return "no-buildinfo"
+    
+    # Rebuild
+    out_dir = work_dir / "out"
+    out_dir.mkdir()
+    
+    if subprocess.run(["debrebuild", "--buildresult=out", "--builder=sbuild", buildinfo], 
+                     cwd=work_dir, capture_output=True).returncode != 0:
+        return "build-failed"
+    
+    # Compare hashes
+    rebuilt = list(out_dir.glob(f"{name}_{version}_{arch}.deb"))
+    cached = cache_dir / f"cache/apt/archives/{name}_{version}_{arch}.deb"
+    
+    if not rebuilt:
+        return "no-output"
+    if not cached.exists():
+        return "no-cached"
+    
+    return "" if sha256(rebuilt[0]) == sha256(cached) else "mismatch"
+
+def main():
+    # Setup
+    manifest = next(Path("/build").glob("*.manifest"))
+    with open(manifest) as f:
+        data = json.load(f)
+    
+    packages = [p for p in data["packages"] if p["type"] == "deb"]
+    results = []
+    
+    # Process packages
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for i, pkg in enumerate(packages, 1):
+            print(f"[{i}/{len(packages)}] {pkg['name']} {pkg['version']}...", end=" ")
+            
+            work_dir = Path(tmpdir) / f"{pkg['name']}-{pkg['version']}"
+            work_dir.mkdir()
+            
+            try:
+                reason = verify_package(pkg, work_dir, Path("/mkosi.cache"))
+                reproducible = not reason
+                print("✓" if reproducible else f"✗ ({reason})")
+            except Exception as e:
+                reason = f"error: {e}"
+                reproducible = False
+                print(f"✗ ({reason})")
+            
+            results.append({
+                "name": pkg["name"],
+                "reproducible": reproducible,
+                "reason": reason
+            })
+            
+            shutil.rmtree(work_dir, ignore_errors=True)
+    
+    # Write report
+    with open("/build/reproducible-report.csv", 'w', newline='') as f:
+        writer = csv.DictWriter(f, ["name", "reproducible", "reason"])
+        writer.writeheader()
+        writer.writerows(results)
+    
+    # Summary
+    total = len(results)
+    repro = sum(r["reproducible"] for r in results)
+    print(f"\nSummary: {repro}/{total} ({repro/total*100:.1f}%) reproducible")
+    print("Report: /build/reproducible-report.csv")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Currently, the Dockerfile works if you run it with
```
sudo podman run --rm -it \
  -v $(pwd)/build:/build:rw \
  -v $(pwd)/mkosi.cache:/mkosi.cache:ro \
  -v /proc:/proc \
  --userns=host \
  --pid=host \
  --privileged \
  --cap-add=ALL \
  --security-opt apparmor:unconfined \
  --security-opt seccomp=unconfined \
  --security-opt systempaths=unconfined
```
(Some of those opts are def not necessary)

The actual verification process works well, but sometimes it can't find the right buildinfo file. Currently looking into this issue.


The verify-lite.py file can be run directly and right now it only reports 4 bad pkgs for the full Bob config, all four of which are just timeouts.