### PR TITLE
Feat: enable searcher to restart lighthouse

### DIFF
--- a/bob/mkosi.extra/etc/sudoers.d/99-searcher
+++ b/bob/mkosi.extra/etc/sudoers.d/99-searcher
@@ -1,1 +1,1 @@
-searcher ALL=(root) NOPASSWD: /usr/bin/toggle, /usr/bin/tdx-init set-passphrase
+searcher ALL=(root) NOPASSWD: /usr/bin/toggle, /usr/bin/tdx-init set-passphrase, /usr/bin/systemctl restart lighthouse

--- a/bob/searchersh.c
+++ b/bob/searchersh.c
@@ -66,7 +66,7 @@ int main(int argc, char *argv[]) {
     if (command == NULL) {
         // If there's no token at all (e.g., empty or whitespace-only string),
         // we print an error and quit.
-        fprintf(stderr, "No command provided. Valid commands are: toggle, status, logs, tail-the-logs,restart-lighthouse, initialize\n");
+        fprintf(stderr, "No command provided. Valid commands are: toggle, status, logs, tail-the-logs, restart-lighthouse, initialize\n");
         free(arg_copy); // free the memory
         return 1;       // return error code 1
     }

--- a/bob/searchersh.c
+++ b/bob/searchersh.c
@@ -187,7 +187,7 @@ int main(int argc, char *argv[]) {
     }
 
     // If we reach here, the command didn't match any of the valid commands
-    fprintf(stderr, "Invalid command. Valid commands are: toggle, status, logs, restart-lighthouse, initialize\n");
+    fprintf(stderr, "Invalid command. Valid commands are: toggle, status, logs, tail-the-logs, restart-lighthouse, initialize\n");
     free(arg_copy); // Clean up allocated memory
     return 1;       // Return error code 1
 }

--- a/bob/searchersh.c
+++ b/bob/searchersh.c
@@ -66,7 +66,7 @@ int main(int argc, char *argv[]) {
     if (command == NULL) {
         // If there's no token at all (e.g., empty or whitespace-only string),
         // we print an error and quit.
-        fprintf(stderr, "No command provided. Valid commands are: toggle, status, logs, initialize\n");
+        fprintf(stderr, "No command provided. Valid commands are: toggle, status, logs, tail-the-logs,restart-lighthouse, initialize\n");
         free(arg_copy); // free the memory
         return 1;       // return error code 1
     }
@@ -98,6 +98,7 @@ int main(int argc, char *argv[]) {
     // 1) "toggle"
     // 2) "status"
     // 3) "logs"
+    // 4) "restart-lighthouse"
     // Anything else -> invalid.
     
     // If command == "toggle", call /usr/bin/toggle via sudo
@@ -176,8 +177,17 @@ int main(int argc, char *argv[]) {
         return 1; // return error code 1
     }
 
+    // If command == "restart-lighthouse", restart the lighthouse systemd service
+    else if (strcmp(command, "restart-lighthouse") == 0) {
+        execl("/usr/bin/sudo", "sudo", "/usr/bin/systemctl", "restart", "lighthouse", NULL);
+        
+        perror("execl failed (restart-lighthouse)");
+        free(arg_copy);
+        return 1;
+    }
+
     // If we reach here, the command didn't match any of the valid commands
-    fprintf(stderr, "Invalid command. Valid commands are: toggle, status, logs, initialize\n");
+    fprintf(stderr, "Invalid command. Valid commands are: toggle, status, logs, restart-lighthouse, initialize\n");
     free(arg_copy); // Clean up allocated memory
     return 1;       // Return error code 1
 }


### PR DESCRIPTION
Enables searchers to restart lighthouse using dropbear forced commands. 

`ssh -i /home/ubuntu/.ssh/id_ed25519 searcher@127.0.0.1 restart-lighthouse`