### PR TITLE
Almost fix running mkosi under rosetta

### DIFF
--- a/lima.yaml
+++ b/lima.yaml
@@ -1,9 +1,13 @@
 images:
 - location: https://cloud.debian.org/images/cloud/bookworm/20250814-2204/debian-12-genericcloud-amd64-20250814-2204.qcow2
   arch: x86_64
-cpus: 4
-memory: 8GiB
-disk: 50GiB
+  digest: sha512:d6cc09dc531ce88a37f222698ee67e41ac9a2325e6207c192c9e1e0cfb547fe33ec091c64e8588e40df7f20bd99f53bcdbebb418b24d6a022a64d04d9b96c798
+- location: https://cloud.debian.org/images/cloud/bookworm/20250814-2204/debian-12-genericcloud-arm64-20250814-2204.qcow2
+  arch: aarch64
+  digest: sha512:ed0502e7b03fb42bf7f9c7fa2283d0db60927301cf868fdc67ed3361d4fe528115ecc5f5197484b577ebc96e30235af2def5eef3d7099be400e236d9eff48f75
+cpus: 6
+memory: 12GiB
+disk: 100GiB
 user:
   name: debian
   uid: 1000
@@ -11,9 +15,11 @@ user:
 rosetta:
   enabled: true
   binfmt: true
+containerd: # we don't need to install extra bunch of deps
+  user: false
 mountTypesUnsupported: [9p]
 mounts:
-- location: "."
+- location: . # cwd of `limactl start` command
   mountPoint: /home/debian/mnt
   writable: true
 ssh:
@@ -30,6 +36,7 @@ provision:
   script: |
     #!/bin/bash
     set -euo pipefail
-    sh <(curl -L https://nixos.org/nix/install) --no-daemon
     mkdir -p ~/.config/nix
     echo 'experimental-features = nix-command flakes' > ~/.config/nix/nix.conf
+    echo 'extra-platforms = x86_64-linux' >> ~/.config/nix/nix.conf
+    sh <(curl -L https://nixos.org/nix/install) --no-daemon --nix-extra-conf-file ~/.config/nix/nix.conf

--- a/rosetta-fix/README.md
+++ b/rosetta-fix/README.md
@@ -1,0 +1,22 @@
+# rosetta-fix
+
+So, this abomination exists to support running mkosi under Rosetta on M\* macs.
+
+For some reason, Rosetta does not translate `mount_setattr` syscall to host
+kernel, instead returning `ENOSYS`. This syscall is used by `mkosi-sandbox`
+to recursively mark mounts as readonly. Unsafe fix would be to remove this call,
+making some mounts writable inside the sandbox.
+
+This thing exists to fix the issue properly (only within `mkosi-sandbox`).
+When running in Rosetta, we actually can call aarch64 binaries from translated
+x86_64 process, so `mkosi-sandbox-mount-rbind.c` is an implementation of
+`mount_rbind` function from `mkosi/sandbox.py`.
+
+In `flake.nix`, it gets cross-compiled as static aarch64 binary, and then we
+patch `mkosi/sandbox.py` to write and exec this binary instead of using syscall.
+
+As `mount_rbind` is called often after setting up sandbox, the patch writes
+this static binary to either `/oldroot/tmp` (if exists), or `/tmp` otherwise.
+This seems to handle all cases I've encountered so far.
+
+Ugly, but works.

--- a/rosetta-fix/mkosi-sandbox-mount-rbind.c
+++ b/rosetta-fix/mkosi-sandbox-mount-rbind.c
@@ -1,0 +1,89 @@
+#include <errno.h>
+#include <linux/fcntl.h>
+#include <linux/mount.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+static void die_with_error(const char *syscall_name, const char *path) {
+  fprintf(stderr, "Error in %s for path '%s': %s\n", syscall_name, path,
+          strerror(errno));
+  exit(1);
+}
+
+/* Syscall wrappers */
+static long sys_open_tree(int dfd, const char *pathname, unsigned int flags) {
+  return syscall(SYS_open_tree, dfd, pathname, flags);
+}
+
+static long sys_mount_setattr(int dfd, const char *path, unsigned int flags,
+                              struct mount_attr *attr, size_t size) {
+  return syscall(SYS_mount_setattr, dfd, path, flags, attr, size);
+}
+
+static long sys_move_mount(int from_dfd, const char *from_pathname, int to_dfd,
+                           const char *to_pathname, unsigned int flags) {
+  return syscall(SYS_move_mount, from_dfd, from_pathname, to_dfd, to_pathname,
+                 flags);
+}
+
+static void mount_rbind(const char *src, const char *dst, uint64_t attrs) {
+  int fd;
+  int r;
+  unsigned int flags;
+
+  flags =
+      AT_NO_AUTOMOUNT | AT_RECURSIVE | AT_SYMLINK_NOFOLLOW | OPEN_TREE_CLONE;
+  fd = sys_open_tree(AT_FDCWD, src, flags);
+  if (fd < 0) {
+    die_with_error("open_tree", src);
+  }
+
+  struct mount_attr attr = {0};
+  attr.attr_set = attrs;
+  flags = AT_EMPTY_PATH | AT_RECURSIVE;
+  r = sys_mount_setattr(fd, "", flags, &attr, MOUNT_ATTR_SIZE_VER0);
+  if (r < 0) {
+    close(fd);
+    die_with_error("mount_setattr", src);
+  }
+
+  r = sys_move_mount(fd, "", AT_FDCWD, dst, MOVE_MOUNT_F_EMPTY_PATH);
+  if (r < 0) {
+    close(fd);
+    die_with_error("move_mount", dst);
+  }
+
+  close(fd);
+}
+
+static void usage(const char *progname) {
+  fprintf(stderr, "Usage: %s <src> <dst> <attrs>\n", progname);
+  fprintf(stderr, "  src:   source path to bind mount\n");
+  fprintf(stderr, "  dst:   destination path for the mount\n");
+  fprintf(stderr, "  attrs: mount attributes as integer\n");
+  exit(1);
+}
+
+int main(int argc, char *argv[]) {
+  if (argc != 4) {
+    usage(argv[0]);
+  }
+
+  const char *src = argv[1];
+  const char *dst = argv[2];
+  char *endptr;
+  uint64_t attrs = strtoull(argv[3], &endptr, 0);
+
+  if (*endptr != '\0') {
+    fprintf(stderr, "Error: attrs must be a valid integer\n");
+    usage(argv[0]);
+  }
+
+  mount_rbind(src, dst, attrs);
+
+  return 0;
+}

--- a/rosetta-fix/mkosi-sandbox.patch
+++ b/rosetta-fix/mkosi-sandbox.patch
@@ -1,0 +1,20 @@
+--- a/mkosi/sandbox.py
++++ b/mkosi/sandbox.py
+@@ -319,6 +319,17 @@
+
+
++import subprocess
++
+ def mount_rbind(src: str, dst: str, attrs: int = 0) -> None:
++    bin = "/tmp/mount-rbind"
++    if os.path.exists("/oldroot"):
++        bin = "/oldroot" + bin
++    if not os.path.exists(bin):
++        open(bin, "wb").write(bytes.fromhex("PLACEHOLDER_HEX_CONTENT"))
++        os.chmod(bin, 0o755)
++    subprocess.run([bin, src, dst, str(attrs)], check=True)
++    return
++
+     """
+     When using the old mount syscall to do a recursive bind mount, mount options are not
+     applied recursively. Because we want to do recursive read-only bind mounts in some cases, we

--- a/scripts/setup_deps.sh
+++ b/scripts/setup_deps.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 [[ "$OSTYPE" == "linux-gnu"* ]] || exit 0
+[[ "${FORCE_LIMA:-}" == "1" ]] && exit 0
 
 LIMA_MSG="Alternatively, you can install Lima from lima-vm.io and run make with FORCE_LIMA=1"
 


### PR DESCRIPTION
- Create rosetta-specific mount_rbind implementation to work around ENOSYS syscall issue
- Patch mkosi to use external binary instead of direct mount_setattr syscall
- Update Lima configuration with multi-arch image support and increased resources
- Add comprehensive documentation explaining the Rosetta translation workaround