### PR TITLE
Fix running mkosi in Lima/Rosetta

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,16 +13,20 @@ endif
 # Default target
 all: build
 
+# Ensure repo was cloned with correct permissions
+check-perms:
+	@scripts/check_perms.sh
+
 # Setup dependencies (Linux only)
 setup:
 	@scripts/setup_deps.sh
 
 # Build module
-build: setup
+build: check-perms setup
 	@$(WRAPPER) mkosi --force -I $(IMAGE).conf
 
 # Build module with devtools profile
-build-dev: setup
+build-dev: check-perms setup
 	@$(WRAPPER) mkosi --force --profile=devtools -I $(IMAGE).conf
 
 # Run measured-boot on the EFI file

--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,13 @@ setup:
 
 # Build module
 build: check-perms setup
-	@$(WRAPPER) mkosi --force -I $(IMAGE).conf
+	@$(WRAPPER) ./scripts/mkosi_wrapper.sh \
+	    --force -I $(IMAGE).conf
 
 # Build module with devtools profile
 build-dev: check-perms setup
-	@$(WRAPPER) mkosi --force --profile=devtools -I $(IMAGE).conf
+	@$(WRAPPER) ./scripts/mkosi_wrapper.sh \
+	    --force --profile=devtools -I $(IMAGE).conf
 
 # Run measured-boot on the EFI file
 measure:

--- a/lima.yaml
+++ b/lima.yaml
@@ -1,10 +1,8 @@
 images:
-  - location: https://cloud.debian.org/images/cloud/bookworm/20250814-2204/debian-12-genericcloud-amd64-20250814-2204.qcow2
+  - location: https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2
     arch: x86_64
-    digest: sha512:d6cc09dc531ce88a37f222698ee67e41ac9a2325e6207c192c9e1e0cfb547fe33ec091c64e8588e40df7f20bd99f53bcdbebb418b24d6a022a64d04d9b96c798
-  - location: https://cloud.debian.org/images/cloud/bookworm/20250814-2204/debian-12-genericcloud-arm64-20250814-2204.qcow2
+  - location: https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-arm64.qcow2
     arch: aarch64
-    digest: sha512:ed0502e7b03fb42bf7f9c7fa2283d0db60927301cf868fdc67ed3361d4fe528115ecc5f5197484b577ebc96e30235af2def5eef3d7099be400e236d9eff48f75
 cpus: 6
 memory: 12GiB
 disk: 100GiB
@@ -16,10 +14,12 @@ rosetta:
   enabled: true
   binfmt: true
 containerd:
+   # Otherwise lima will install couple of hundreds of MB of containerd stuff,
+   # which we don't need.
   user: false
 mountTypesUnsupported: [9p]
 mounts:
-  - location: "."
+  - location: "." # cwd of `limactl start` command
     mountPoint: /home/debian/mnt
     writable: true
 ssh:
@@ -30,7 +30,7 @@ provision:
       #!/bin/bash
       set -euo pipefail
       apt-get update
-      apt-get install -y curl git sudo debian-archive-keyring build-essential
+      apt-get install -y curl git sudo debian-archive-keyring build-essential uidmap
       echo "debian ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/debian
   - mode: user
     script: |

--- a/lima.yaml
+++ b/lima.yaml
@@ -36,7 +36,12 @@ provision:
     script: |
       #!/bin/bash
       set -euo pipefail
+
       mkdir -p ~/.config/nix
       echo 'experimental-features = nix-command flakes' > ~/.config/nix/nix.conf
       echo 'extra-platforms = x86_64-linux' >> ~/.config/nix/nix.conf
       sh <(curl -L https://nixos.org/nix/install) --no-daemon --nix-extra-conf-file ~/.config/nix/nix.conf
+
+      # nix adds its env to .profile, but not to .bashrc
+      # .profile is not sourced when connecting through ssh, so copy to .bashrc
+      grep nix .profile >> .bashrc

--- a/scripts/check_perms.sh
+++ b/scripts/check_perms.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+check_perms() {
+    local path="$1"
+    local expected_perms="$2"
+
+    if [ ! -e "$path" ]; then
+        echo "Error: $path not found"
+        return 1
+    fi
+
+    # Cross-platform way to get octal permissions
+    perms=$(stat -c "%a" "$path" 2>/dev/null || stat -f "%OLp" "$path" 2>/dev/null)
+
+    if [ "$perms" = "$expected_perms" ]; then
+        return 0
+    else
+        echo "$path has incorrect permissions ($perms), expected $expected_perms"
+        return 1
+    fi
+}
+
+err=0
+
+check_perms "base/mkosi.skeleton/init" "755" || err=1
+check_perms "base/mkosi.skeleton/etc" "755" || err=1
+check_perms "base/mkosi.skeleton/etc/resolv.conf" "644" || err=1
+
+if [ $err -eq 1 ]; then
+    echo "Permission check failed!"
+    echo "Ensure you have cloned the repo with umask 0022"
+    exit 1
+fi

--- a/scripts/env_wrapper.sh
+++ b/scripts/env_wrapper.sh
@@ -98,7 +98,7 @@ if should_use_lima; then
         )
     fi
 
-    lima_exec "cd ~/mnt && nix develop -c ${cmd[*]@Q}"
+    lima_exec "cd ~/mnt && /home/debian/.nix-profile/bin/nix develop -c ${cmd[*]@Q}"
 
     if is_mkosi_cmd; then
         lima_exec "mkdir -p ~/mnt/build; mv '$mkosi_output'/* ~/mnt/build/ || true"

--- a/scripts/env_wrapper.sh
+++ b/scripts/env_wrapper.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-LIMA_VM="tee-builder"
+LIMA_VM="${LIMA_VM:-tee-builder}"
 
 # Check if Lima should be used
 should_use_lima() {
@@ -17,13 +17,27 @@ setup_lima() {
         echo -e "Visit: https://lima-vm.io/docs/installation/"
         exit 1
     fi
-    
+
     # Create VM if it doesn't exist
     if ! limactl list 2>/dev/null | grep -q "$LIMA_VM"; then
+        lima_args=()
+        if [ -n "${LIMA_CPUS:-}" ]; then
+            lima_args+=("--cpus" "$LIMA_CPUS")
+        fi
+        if [ -n "${LIMA_MEMORY:-}" ]; then
+            lima_args+=("--memory" "$LIMA_MEMORY")
+        fi
+        if [ -n "${LIMA_DISK:-}" ]; then
+            lima_args+=("--disk" "$LIMA_DISK")
+        fi
+
         echo -e "Creating $LIMA_VM VM..."
-        limactl create -y --name "$LIMA_VM" lima.yaml
+        limactl create -y \
+            --name "$LIMA_VM" \
+            "${lima_args[@]}" \
+            lima.yaml
     fi
-    
+
     # Start VM if not running
     if ! limactl list 2>/dev/null | grep "$LIMA_VM" | grep -q "Running"; then
         echo -e "Starting $LIMA_VM VM..."
@@ -45,12 +59,49 @@ fi
 cmd=("$@")
 if should_use_lima; then
     setup_lima
-    cache_dir="/home/debian/mkosi-cache"
-    cache_cmd="mkdir -p \"$cache_dir\" || true"
+
+    mkosi_cache=/home/debian/mkosi-cache
+    mkosi_output=/home/debian/mkosi-output
+
     if [[ "${cmd[0]}" == "mkosi" ]]; then
-        cmd+=("--cache-directory=$cache_dir")
+        limactl shell "$LIMA_VM" mkdir -p "$mkosi_cache" "$mkosi_output"
+
+        cmd=(
+            # First off, we need to run mkosi in a new user namespace,
+            # because it creates files owned by multiple uids/gids, and we
+            # either need to run as root, or use this unshare, which is safer.
+            # See also:
+            # https://manpages.debian.org/unstable/mkosi/mkosi.1.en.html#:~:text=Why%20do%20I%20see%20failures%20to%20chown%20files%20when%20building%20images
+            "unshare"
+            "--map-auto" "--map-current-user"
+            "--setuid=0" "--setgid=0"
+            "--"
+            # Next, we use which because actual file is somewhere in /nix/store
+            # and it's easier to explicitly specify it here instead of passing
+            # $PATH.
+            '$(which mkosi)'
+            # Pass all original arguments except the first one (mkosi)
+            "${cmd[@]:1}"
+            # We can't use default cache dir from mnt/, because it is mounted
+            # from host, and mkosi will try to preserve root/other permissions
+            # without success.
+            "--cache-directory=$mkosi_cache"
+            # For the same reason, we need to use separate output dir.
+            # mkosi tries to preserve ownership of output files, which fails,
+            # as it is running from root in a user namespace.
+            "--output-dir=$mkosi_output"
+        )
     fi
-    limactl shell --workdir "/home/debian/mnt" "$LIMA_VM" bash -c "$cache_cmd; nix develop -c ${cmd[*]@Q}"
+
+    limactl shell "$LIMA_VM" bash -c \
+        "cd /home/debian/mnt && nix develop -c bash -c '${cmd[*]}'"
+
+    limactl shell "$LIMA_VM" mkdir -p /home/debian/mnt/build
+    # TODO: quoting & run only after mkosi commands
+    limactl shell "$LIMA_VM" bash -c "cp -rv $mkosi_output/* /home/debian/mnt/build/ || true"
+    echo "Check ./build/ directory for output files"
+    echo
+
     echo "Note: Lima VM is still running. To stop it, run: limactl stop $LIMA_VM"
 else
     if in_nix_env; then

--- a/scripts/env_wrapper.sh
+++ b/scripts/env_wrapper.sh
@@ -19,31 +19,40 @@ setup_lima() {
     fi
 
     # Create VM if it doesn't exist
-    if ! limactl list 2>/dev/null | grep -q "$LIMA_VM"; then
-        lima_args=()
+    if ! limactl list "$LIMA_VM" > /dev/null 2>&1; then
+        declare -a args=()
         if [ -n "${LIMA_CPUS:-}" ]; then
-            lima_args+=("--cpus" "$LIMA_CPUS")
+            args+=("--cpus" "$LIMA_CPUS")
         fi
         if [ -n "${LIMA_MEMORY:-}" ]; then
-            lima_args+=("--memory" "$LIMA_MEMORY")
+            args+=("--memory" "$LIMA_MEMORY")
         fi
         if [ -n "${LIMA_DISK:-}" ]; then
-            lima_args+=("--disk" "$LIMA_DISK")
+            args+=("--disk" "$LIMA_DISK")
         fi
 
         echo -e "Creating $LIMA_VM VM..."
-        limactl create -y \
-            --name "$LIMA_VM" \
-            "${lima_args[@]}" \
-            lima.yaml
+        # Portable way to expand array on bash 3 & 4
+        limactl create -y --name "$LIMA_VM" ${args[@]+"${args[@]}"} lima.yaml
     fi
 
     # Start VM if not running
-    if ! limactl list 2>/dev/null | grep "$LIMA_VM" | grep -q "Running"; then
+    status=$(limactl list "$LIMA_VM" --format "{{.Status}}")
+    if [ "$status" != "Running" ]; then
         echo -e "Starting $LIMA_VM VM..."
         limactl start -y "$LIMA_VM"
-        rm NvVars 2>/dev/null || true # Remove stray file created by QEMU
+
+        rm -f NvVars # Remove stray file created by QEMU
     fi
+}
+
+# Execute command in Lima VM
+lima_exec() {
+    # Allocate TTY (-t) for pretty output in nix commands
+    # Add -o LogLevel=QUIET to suppress SSH "Shared connection closed" messages
+    ssh -F "$HOME/.lima/$LIMA_VM/ssh.config" "lima-$LIMA_VM" \
+        -t -o LogLevel=QUIET \
+        -- "$@"
 }
 
 # Check if in nix environment
@@ -57,31 +66,27 @@ if [ $# -eq 0 ]; then
 fi
 
 cmd=("$@")
+
+is_mkosi_cmd() {
+    [[ "${cmd[0]}" == "./scripts/mkosi_wrapper.sh" ]]
+}
+
+if is_mkosi_cmd && [ -n "${MKOSI_EXTRA_ARGS:-}" ]; then
+    # TODO: these args will be overriden by default cache/out dir in Lima
+    # Not a big deal, but might worth fixing
+    cmd+=($MKOSI_EXTRA_ARGS)
+fi
+
 if should_use_lima; then
     setup_lima
 
     mkosi_cache=/home/debian/mkosi-cache
     mkosi_output=/home/debian/mkosi-output
 
-    if [[ "${cmd[0]}" == "mkosi" ]]; then
-        limactl shell "$LIMA_VM" mkdir -p "$mkosi_cache" "$mkosi_output"
+    if is_mkosi_cmd; then
+        lima_exec mkdir -p "$mkosi_cache" "$mkosi_output"
 
-        cmd=(
-            # First off, we need to run mkosi in a new user namespace,
-            # because it creates files owned by multiple uids/gids, and we
-            # either need to run as root, or use this unshare, which is safer.
-            # See also:
-            # https://manpages.debian.org/unstable/mkosi/mkosi.1.en.html#:~:text=Why%20do%20I%20see%20failures%20to%20chown%20files%20when%20building%20images
-            "unshare"
-            "--map-auto" "--map-current-user"
-            "--setuid=0" "--setgid=0"
-            "--"
-            # Next, we use which because actual file is somewhere in /nix/store
-            # and it's easier to explicitly specify it here instead of passing
-            # $PATH.
-            '$(which mkosi)'
-            # Pass all original arguments except the first one (mkosi)
-            "${cmd[@]:1}"
+        cmd+=(
             # We can't use default cache dir from mnt/, because it is mounted
             # from host, and mkosi will try to preserve root/other permissions
             # without success.
@@ -93,14 +98,14 @@ if should_use_lima; then
         )
     fi
 
-    limactl shell "$LIMA_VM" bash -c \
-        "cd /home/debian/mnt && nix develop -c bash -c '${cmd[*]}'"
+    lima_exec "cd ~/mnt && nix develop -c ${cmd[*]@Q}"
 
-    limactl shell "$LIMA_VM" mkdir -p /home/debian/mnt/build
-    # TODO: quoting & run only after mkosi commands
-    limactl shell "$LIMA_VM" bash -c "cp -rv $mkosi_output/* /home/debian/mnt/build/ || true"
-    echo "Check ./build/ directory for output files"
-    echo
+    if is_mkosi_cmd; then
+        lima_exec "mkdir -p ~/mnt/build; mv '$mkosi_output'/* ~/mnt/build/ || true"
+
+        echo "Check ./build/ directory for output files"
+        echo
+        fi
 
     echo "Note: Lima VM is still running. To stop it, run: limactl stop $LIMA_VM"
 else

--- a/scripts/mkosi_wrapper.sh
+++ b/scripts/mkosi_wrapper.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+# This script is called in place of "mkosi" to ensure correct user namespace
+# setup.
+
+# This wrapper is called in both cases: plain host nix and Lima VM.
+
+cmd=(
+    # We need to run mkosi in a new user namespace,
+    # because it creates files owned by multiple uids/gids, and we
+    # either need to run as root, or use this unshare, which is safer.
+    # See also:
+    # https://manpages.debian.org/unstable/mkosi/mkosi.1.en.html#:~:text=Why%20do%20I%20see%20failures%20to%20chown%20files%20when%20building%20images
+    "unshare"
+    "--map-auto" "--map-current-user"
+    "--setuid=0" "--setgid=0"
+    "--"
+    # unshare clears environment, so we need to pass PATH explicitly
+    "env" "PATH=$PATH"
+    # Run mkosi with all passed arguments
+    "mkosi" "${@:1}"
+)
+
+exec "${cmd[@]}"

--- a/scripts/setup_deps.sh
+++ b/scripts/setup_deps.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 [[ "$OSTYPE" == "linux-gnu"* ]] || exit 0
+[[ "${FORCE_LIMA:-}" == "1" ]] && exit 0
 
 LIMA_MSG="Alternatively, you can install Lima from lima-vm.io and run make with FORCE_LIMA=1"
 


### PR DESCRIPTION
- Add uidmap package to lima.yaml bootcmd to support unshare
- Use latest debian-12 images, pinned versions expire after some time
- Make LIMA_VM environment variable configurable with default fallback
- Add LIMA_{CPUS,MEMORY,DISK} variables to configure lima VM resources
- Implement proper mkosi execution in user namespace with unshare command
- Add separate cache and output directories to avoid permission issues
  with mounted filesystem
- Copy mkosi output back to host build directory after execution
- Add FORCE_LIMA environment variable check to skip dependency setup on Linux
- Add make target and script to ensure correct permissions in cloned
  repo
