### PR TITLE
Add FB Protect IPs

### DIFF
--- a/bob/mkosi.extra/usr/bin/init-firewall.sh
+++ b/bob/mkosi.extra/usr/bin/init-firewall.sh
@@ -32,6 +32,12 @@ echo "Initializing firewall with separate inbound/outbound chains..."
 
 TITAN_BUILDER_IP="52.207.17.217"
 
+# TEE Searcher IPs
+FLASHBOTS_TX_IP1="3.136.107.142"
+FLASHBOTS_TX_IP2="3.149.14.12"
+FLASHBOTS_BUNDLE_IP1="18.221.59.61"
+FLASHBOTS_BUNDLE_IP2="3.15.88.156"
+
 ###############################################################################
 # Ports
 ###############################################################################
@@ -162,6 +168,15 @@ iptables -A $CHAIN_ALWAYS_ON_OUT -p udp --dport $NTP_PORT \
 iptables -A $CHAIN_ALWAYS_ON_OUT -p tcp -d $TITAN_BUILDER_IP --dport $TITAN_BUNDLE_PORT_HTTPS \
     -m conntrack --ctstate NEW -j ACCEPT
 
+# Flashbots bundle endpoints (always on)
+# Security note: This is a side channel.
+# While the operator will not be able to see the content of the packets, 
+# they can observe the presence or absence of packets.
+iptables -A $CHAIN_ALWAYS_ON_OUT -p tcp -d $FLASHBOTS_BUNDLE_IP1 --dport $HTTPS_PORT \
+    -m conntrack --ctstate NEW -j ACCEPT
+iptables -A $CHAIN_ALWAYS_ON_OUT -p tcp -d $FLASHBOTS_BUNDLE_IP2 --dport $HTTPS_PORT \
+    -m conntrack --ctstate NEW -j ACCEPT
+
 # Return from ALWAYS_ON_OUT back to caller (OUTPUT chain -> MODE_SELECTOR_OUT) 
 iptables -A $CHAIN_ALWAYS_ON_OUT -j RETURN
 
@@ -188,6 +203,10 @@ iptables -A $CHAIN_MAINTENANCE_IN -j RETURN
 ###########################################################################
 # (9) MAINTENANCE_OUT: Outbound rules for Maintenance Mode
 ###########################################################################
+# Block Flashbots protect tx endpoints during maintenance
+iptables -A $CHAIN_MAINTENANCE_OUT -p tcp -d $FLASHBOTS_TX_IP1 -j DROP
+iptables -A $CHAIN_MAINTENANCE_OUT -p tcp -d $FLASHBOTS_TX_IP2 -j DROP
+
 # DNS (UDP/TCP 53)
 # Note: Searchers will only have DNS in maintenance mode! 
 iptables -A $CHAIN_MAINTENANCE_OUT -p udp --dport $DNS_PORT \
@@ -226,6 +245,12 @@ iptables -A $CHAIN_PRODUCTION_IN -j RETURN
 ###########################################################################
 # Titan state diff WSS
 iptables -A $CHAIN_PRODUCTION_OUT -p tcp -d $TITAN_BUILDER_IP --dport $TITAN_STATE_DIFF_PORT_WSS \
+    -m conntrack --ctstate NEW -j ACCEPT
+
+# Flashbots protect tx endpoints (production only)
+iptables -A $CHAIN_PRODUCTION_OUT -p tcp -d $FLASHBOTS_TX_IP1 --dport $HTTPS_PORT \
+    -m conntrack --ctstate NEW -j ACCEPT
+iptables -A $CHAIN_PRODUCTION_OUT -p tcp -d $FLASHBOTS_TX_IP2 --dport $HTTPS_PORT \
     -m conntrack --ctstate NEW -j ACCEPT
 
 # Return from PRODUCTION_OUT back to caller (OUTPUT chain -> END) 

--- a/bob/mkosi.extra/usr/bin/toggle
+++ b/bob/mkosi.extra/usr/bin/toggle
@@ -107,8 +107,11 @@ check_delay() {
 kill_established_connections() {
     local old_mode="$1"
     if [ "$old_mode" = "production" ]; then
-        echo "Killing leftover production flows (port $TITAN_STATE_DIFF_PORT_WSS)..."
+        echo "Killing leftover production flows:"
+        echo " - Titan state diff port $TITAN_STATE_DIFF_PORT_WSS"
+        echo " - HTTPS port $HTTPS_PORT (Flashbots protect tx)"
         $CONNTRACK -D -p tcp --dport $TITAN_STATE_DIFF_PORT_WSS 2>/dev/null
+        $CONNTRACK -D -p tcp --dport $HTTPS_PORT 2>/dev/null
 
     elif [ "$old_mode" = "maintenance" ]; then
         echo "Killing leftover maintenance flows:"

--- a/bob/readme.md
+++ b/bob/readme.md
@@ -1,4 +1,4 @@
-BOB
+TEE Searcher
 ===
 
 Using Intel TDX, Flashbots has built a way for searchers to trustlessly backrun transactions with full information, without exposing frontrunning risks. This product is currently live on Ethereum mainnet for searching on Flashbots Protect and Titan Builder's bottom of block.
@@ -146,11 +146,8 @@ Searchers will need to build the image locally in order to produce the measureme
 git clone https://github.com/flashbots/flashbots-images.git
 cd flashbots-images
 
-# enter the development environment
-nix develop -c $SHELL
-
-# build with Azure compatibility
-mkosi --force -I bob.conf --profile=azure
+# build the BOB (TEE searcher sandbox) image
+make build IMAGE=bob
 ```
 
 ### 2. audit the VM image
@@ -350,22 +347,22 @@ For more information, please visit the [Flashbots Protect and MEV-Share Order Fl
 
 To subscribe to transactions, connect to the server:
 ```
-https://mevshare.bob.flashbots.net:443
+https://tx.tee-searcher.flashbots.net
 ```
 
 To submit bundles, connect to the server:
 ```
-https://ofa.bob.flashbots.net:443
+https://backruns.tee-searcher.flashbots.net
 ```
 
 
 Please run the following command to **cache DNS resolution** (remember: DNS is not available during production mode!)
 
 ```bash
-echo "3.149.14.12 mevshare.bob.flashbots.net" >> /etc/hosts
-echo "3.136.107.142 mevshare.bob.flashbots.net" >> /etc/hosts
-echo "18.221.59.61 ofa.bob.flashbots.net" >> /etc/hosts
-echo "3.15.88.156 ofa.bob.flashbots.net" >> /etc/hosts
+echo "3.149.14.12 tx.tee-searcher.flashbots.net" >> /etc/hosts
+echo "3.136.107.142 tx.tee-searcher.flashbots.net" >> /etc/hosts
+echo "18.221.59.61 backruns.tee-searcher.flashbots.net" >> /etc/hosts
+echo "3.15.88.156 backruns.tee-searcher.flashbots.net" >> /etc/hosts
 ```
 
 ### Searching on Titan Builder's Bottom of Block


### PR DESCRIPTION
- Added Flashbots protect tx IPs (production-only access, blocked in maintenance mode)
- Added Flashbots bundle IPs (always-on access)
- Updated toggle script to kill all HTTPS connections when exiting production mode