### PR TITLE
Fix race condition in azure provisioning service

### DIFF
--- a/bob/mkosi.extra/etc/systemd/system/searcher-firewall.service
+++ b/bob/mkosi.extra/etc/systemd/system/searcher-firewall.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Searcher Network and Firewall Rules
-After=network.target network-setup.service
-Requires=network-setup.service
+After=azure-complete-provisioning.service
+Requires=azure-complete-provisioning.service
 
 [Service]
 Type=oneshot

--- a/mkosi.profiles/azure/azure-complete-provisioning
+++ b/mkosi.profiles/azure/azure-complete-provisioning
@@ -4,6 +4,11 @@
 
 set -e
 
+if ! dmidecode -s system-manufacturer 2>/dev/null | grep -q "Microsoft Corporation"; then
+    echo "Not running on Azure, skipping provisioning"
+    exit 0
+fi
+
 attempts=1
 retrieved_goal_state=false
 until [ "$attempts" -gt 5 ]
@@ -12,6 +17,8 @@ do
     goalstate=$(curl --fail -v -X 'GET' -H "x-ms-agent-name: azure-vm-register" \
                                         -H "Content-Type: text/xml;charset=utf-8" \
                                         -H "x-ms-version: 2012-11-30" \
+                                        --connect-timeout 10 \
+                                        --max-time 30 \
                                           "http://168.63.129.16/machine/?comp=goalstate")
     if [ $? -eq 0 ]
     then

--- a/mkosi.profiles/azure/mkosi.conf
+++ b/mkosi.profiles/azure/mkosi.conf
@@ -1,2 +1,4 @@
 [Content]
 SkeletonTrees=azure-complete-provisioning.service:/etc/systemd/system/azure-complete-provisioning.service
+SkeletonTrees=azure-complete-provisioning:/usr/bin/azure-complete-provisioning
+Packages=dmidecode


### PR DESCRIPTION
This PR:
 - Waits to setup Bob firewall rules only after the azure provisioning service has completed
 - Skips the azure provisioning service entirely if the hardware's `system-manufacturer` isn't Microsoft, meaning it will only run in an actual Azure VM
 - Moves the azure provisioning binary into the azure profile, so it's not included in non-azure-compatible images
 - Adds a request timeout to the http request made by the provisioning service to prevent it from hanging for 10 minutes