### PR TITLE
chore: add qemu-utils to be able to use qemu-img

### DIFF
--- a/scripts/setup_deps.sh
+++ b/scripts/setup_deps.sh
@@ -17,6 +17,7 @@ missing=()
 # Check for missing dependencies
 
 cmd_exists curl || missing+=("curl")
+cmd_exists qemu-img || missing+=("qemu-utils")
 
 ls /usr/share/keyrings/debian-archive* &>/dev/null 2>&1 || missing+=("debian-archive-keyring")
 
@@ -49,7 +50,7 @@ fi
 
 apt_pkgs=()
 for dep in "${missing[@]}"; do
-    [[ "$dep" == "curl" || "$dep" == "debian-archive-keyring" ]] && apt_pkgs+=("$dep")
+    [[ "$dep" == "curl" || "$dep" == "debian-archive-keyring" || "$dep" == "qemu-utils" ]] && apt_pkgs+=("$dep")
 done
 
 if [ ${#apt_pkgs[@]} -gt 0 ]; then


### PR DESCRIPTION
This is required for Lima to work with QCOW2 images. 

Building an image with make fails due to missing package: 

```txt
Creating tee-builder VM...
INFO[0000] Terminal is not available, proceeding without opening an editor
INFO[0000] Attempting to download the image              arch=x86_64 digest= location="https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2"
Downloading the image (debian-12-genericcloud-amd64.qcow2)
330.75 MiB / 330.75 MiB [---------------------------------] 100.00% 100.38 MiB/s
INFO[0003] Downloaded the image from "https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2"
FATA[0003] failed to get the information of base disk "/home/shared/.lima/tee-builder/basedisk": failed to run [qemu-img info --output=json --force-share /home/shared/.lima/tee-builder/basedisk]: stdout="", stderr="": exec: "qemu-img": executable file not found in $PATH
```