### PR TITLE
Update mkosi version format

### DIFF
--- a/mkosi.version
+++ b/mkosi.version
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-# mkosi doesn't support customizing version script path in config files,
-# so we store it in the root of repo / cwd of running mkosi commands.
-
-# careful: this script is executed on host, and not in any of sandboxes
+# This script generates the image version string for mkosi images.
+# Check: https://github.com/systemd/mkosi/blob/main/mkosi/resources/man/mkosi.1.md
+#
+# Note: This script executes on the host, not inside any mkosi sandbox.
 
 # Add current directory to git safe directories if not already present
 if ! git config --global --get-all safe.directory | grep -Fxq "$PWD"; then

--- a/mkosi.version
+++ b/mkosi.version
@@ -11,12 +11,13 @@ if ! git config --global --get-all safe.directory | grep -Fxq "$PWD"; then
     git config --global --add safe.directory "$PWD"
 fi
 
-commit_date=$(TZ=UTC0 git show -s --date=format:'%Y-%m-%d' --format='%ad')
+commit_timestamp=$(git show -s --format=%ct)
 commit_hash=$(git rev-parse --short=6 HEAD)
 dirty_suffix=""
 if [ -n "$(git status --porcelain)" ]; then
-    dirty_suffix="-dirty"
+    dirty_suffix="_dirty"
 fi
 
-# example value: 2025-06-26.a1b2c3d-dirty
-echo "${commit_date}.${commit_hash}${dirty_suffix}"
+# Example: 1720636800_a1b2c3d_dirty
+# Resulting image name: <IMAGE_ID>_1720636800_a1b2c3d_dirty
+echo "${commit_timestamp}_${commit_hash}${dirty_suffix}"


### PR DESCRIPTION
From:

```bash
<IMAGE_ID>_2026-01-26.87dc38-dirty
# bob-l1-dev_2026-01-26.87dc38-dirty
```

To:

```bash
<IMAGE_ID>_1720636800_a1b2c3d_dirty
# bob-l1-dev_1720636800_a1b2c3d_dirty
```

- Changing date format to unix timestamp
- Uniforming `.` and `-` to `_` as a separator and leaving `-` for the image name 