### PR TITLE
fix: install libcryptsetup to Debian multiarch path

### DIFF
--- a/modules/flashbox/common/mkosi.build
+++ b/modules/flashbox/common/mkosi.build
@@ -16,7 +16,7 @@ make_git_package \
     "https://gitlab.com/cryptsetup/cryptsetup" \
     './autogen.sh && ./configure --with-crypto_backend=kernel --disable-veritysetup --disable-integritysetup --disable-asciidoc && make -j$(nproc)' \
     ".libs/cryptsetup:/usr/sbin/cryptsetup" \
-    ".libs/libcryptsetup.so.12.11.0:/usr/lib/libcryptsetup.so.12"
+    ".libs/libcryptsetup.so.12.11.0:/usr/lib/x86_64-linux-gnu/libcryptsetup.so.12"
 
 # Build delay-pipe
 build_rust_package \


### PR DESCRIPTION
While working on a new `benchmark` mkosi profile, I added several packages including `fio`. After building the Flashbox L1 image and running `initialize`, it failed with `Error: formatting disk: exit status 1`.

The build logs showed that `fio` pulls in Debian's `libcryptsetup12` (v2.7.5-2) as a transitive dependency (`fio` → `librbd1` → `libcryptsetup12`), which gets installed to `/usr/lib/x86_64-linux-gnu/libcryptsetup.so.12`. This path has higher priority in the dynamic linker than our custom build at `/usr/lib/libcryptsetup.so.12`, so at runtime the wrong library gets loaded.

### Fix

Changed the artifact destination from `/usr/lib` to `/usr/lib/x86_64-linux-gnu`. And now it works again.

