### PR TITLE
Dynamically size ESP partition to support images > 512MB

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,53 +44,56 @@
       src = pkgs.fetchFromGitHub {
         owner = "flashbots";
         repo = "dstack-mr-gcp";
-        rev = "503e7c506f89f9d81be04025c90921778b26f0a4";
-        sha256 = "sha256-z6STTgcOXatiqA2rlpzwRyvAwnXrK30oNDCJqtIp7/8=";
+        rev = "ecf3284b72a507fd005de91d49f7372490cf6995";
+        sha256 = "sha256-1rcm9sIZuvCojNN2HMPrsECYn9sd8eVChsgwleo8nFY=";
       };
       vendorHash = "sha256-glOyRTrIF/zP78XGV+v58a1Bec6C3Fvc5c8G3PglzPM=";
     };
     mkosi = system: let
       pkgsForSystem = import nixpkgs {inherit system;};
-      mkosi-unwrapped = (pkgsForSystem.mkosi.override {
-        extraDeps = with pkgsForSystem;
-          [
-            apt
-            dpkg
-            gnupg
-            debootstrap
-            squashfsTools
-            dosfstools
-            e2fsprogs
-            mtools
-            mustache-go
-            cryptsetup
-            gptfdisk
-            util-linux
-            zstd
-            which
-            qemu-utils
-            parted
-            unzip
-            jq
-          ]
-          ++ [reprepro];
-      }).overrideAttrs (old: {
-        src = pkgsForSystem.fetchFromGitHub {
-          owner = "systemd";
-          repo = "mkosi";
-          rev = "df51194bc2d890d4c267af644a1832d2d53339ac";
-          hash = "sha256-rGGzE9xIR8WvK07GBnaAmeLpmnM3Uy51wqyrmuHuWXo=";
-        };
-        # TODO: remove these patch hunks from upstream nixpkgs next time mkosi has a release
-        # The latest mkosi doesn't need them
-        patches = pkgs.lib.drop 2 old.patches;
-        postPatch = let fd = "${pkgs.patchutils}/bin/filterdiff"; in ''
-          { ${fd} -x '*/run.py' --hunks=x2   ${builtins.elemAt old.patches 0}
-            ${fd} -i '*/run.py' --hunks=x1-2 ${builtins.elemAt old.patches 0}
-            ${fd} --hunks=x1                 ${builtins.elemAt old.patches 1}
-          } | patch -p1
-        '';
-      });
+      mkosi-unwrapped =
+        (pkgsForSystem.mkosi.override {
+          extraDeps = with pkgsForSystem;
+            [
+              apt
+              dpkg
+              gnupg
+              debootstrap
+              squashfsTools
+              dosfstools
+              e2fsprogs
+              mtools
+              mustache-go
+              cryptsetup
+              gptfdisk
+              util-linux
+              zstd
+              which
+              qemu-utils
+              parted
+              unzip
+              jq
+            ]
+            ++ [reprepro];
+        }).overrideAttrs (old: {
+          src = pkgsForSystem.fetchFromGitHub {
+            owner = "systemd";
+            repo = "mkosi";
+            rev = "df51194bc2d890d4c267af644a1832d2d53339ac";
+            hash = "sha256-rGGzE9xIR8WvK07GBnaAmeLpmnM3Uy51wqyrmuHuWXo=";
+          };
+          # TODO: remove these patch hunks from upstream nixpkgs next time mkosi has a release
+          # The latest mkosi doesn't need them
+          patches = pkgs.lib.drop 2 old.patches;
+          postPatch = let
+            fd = "${pkgs.patchutils}/bin/filterdiff";
+          in ''
+            { ${fd} -x '*/run.py' --hunks=x2   ${builtins.elemAt old.patches 0}
+              ${fd} -i '*/run.py' --hunks=x1-2 ${builtins.elemAt old.patches 0}
+              ${fd} --hunks=x1                 ${builtins.elemAt old.patches 1}
+            } | patch -p1
+          '';
+        });
     in
       # Create a wrapper script that runs mkosi with unshare
       # Unshare is needed to create files owned by multiple uids/gids

--- a/mkosi.profiles/gcp/mkosi.postoutput
+++ b/mkosi.profiles/gcp/mkosi.postoutput
@@ -10,11 +10,20 @@ cp ${OUTPUTDIR}/${IMAGE_ID}_${IMAGE_VERSION}.efi ${OUTPUTDIR}/esp/EFI/BOOT/BOOTX
 find ${OUTPUTDIR}/esp -exec touch -d "@${SOURCE_DATE_EPOCH}" {} +
 rm -f ${OUTPUTDIR}/${IMAGE_ID}_${IMAGE_VERSION}.raw
 
-# Hack to use the newer systemd-repart from nix instead of mkosi.tools one
-# TODO: remove after updating mkosi
-PATH="${PATH#/usr/bin:/usr/sbin:}" systemd-repart --empty=create \
-  --size=1G \
-  --definitions=mkosi.profiles/gcp/repart.d \
+# Dynamically size ESP partition and disk from EFI file
+MIB=$((1024 * 1024))
+EFI_BYTES=$(stat -c%s "${OUTPUTDIR}/${IMAGE_ID}_${IMAGE_VERSION}.efi")
+ESP_BYTES=$(( EFI_BYTES + 32 * MIB ))
+DISK_GIB=$(numfmt --to-unit=1Gi --round=up $(( ESP_BYTES + MIB ))) # + 1MiB GPT overhead
+
+REPART_TMPDIR=$(mktemp -d)
+cp mkosi.profiles/gcp/repart.d/00-uki.conf "${REPART_TMPDIR}/00-uki.conf"
+echo "SizeMinBytes=${ESP_BYTES}" >> "${REPART_TMPDIR}/00-uki.conf"
+echo "SizeMaxBytes=${ESP_BYTES}" >> "${REPART_TMPDIR}/00-uki.conf"
+
+systemd-repart --empty=create \
+  --size=${DISK_GIB}G \
+  --definitions="${REPART_TMPDIR}" \
   --copy-source=${OUTPUTDIR} \
   --seed=630b5f72-a36a-4e83-b23d-6ef47c82fd9c \
   --dry-run=no \

--- a/mkosi.profiles/gcp/repart.d/00-uki.conf
+++ b/mkosi.profiles/gcp/repart.d/00-uki.conf
@@ -4,5 +4,3 @@ Format=vfat
 CopyFiles=/esp:/
 Minimize=off
 UUID=87654321-4321-8765-4321-876543218765
-SizeMinBytes=524288000
-SizeMaxBytes=524288000


### PR DESCRIPTION
@0x416e746f6e Mentioned that ~we're going to have a couple images that go just over 512MB soon~ we need to support images over 512MB, so I modified the gcp postoutput script to dynamically round up the disk size to the nearest GiB in a way that's deterministically computable based on the efi size alone.  This PR should be merged with https://github.com/flashbots/dstack-mr-gcp/pull/12