### PR TITLE
Shell scripts should use #!/usr/bin/env bash and flake.nix should add all needed tools to development shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -106,7 +106,15 @@
     devShells = builtins.listToAttrs (map (system: {
       name = system;
       value.default = pkgs.mkShell {
-        nativeBuildInputs = [(mkosi system) measured-boot measured-boot-gcp];
+        nativeBuildInputs = with pkgs; [
+          (mkosi system)
+          measured-boot
+          measured-boot-gcp
+          bash
+          curl
+          git
+          jq
+        ];
         shellHook = ''
           mkdir -p mkosi.packages mkosi.cache mkosi.builddir ~/.cache/mkosi
           touch mkosi.builddir/mkosi.sources

--- a/flake.nix
+++ b/flake.nix
@@ -113,7 +113,6 @@
           bash
           curl
           git
-          jq
         ];
         shellHook = ''
           mkdir -p mkosi.packages mkosi.cache mkosi.builddir ~/.cache/mkosi

--- a/mkosi.profiles/azure/mkosi.postoutput
+++ b/mkosi.profiles/azure/mkosi.postoutput
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 EFI_FILE="${OUTPUTDIR}/${IMAGE_ID}_${IMAGE_VERSION}.efi"

--- a/mkosi.profiles/devtools/mkosi.postinst
+++ b/mkosi.profiles/devtools/mkosi.postinst
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 

--- a/mkosi.profiles/gcp/mkosi.postinst
+++ b/mkosi.profiles/gcp/mkosi.postinst
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 

--- a/mkosi.profiles/gcp/mkosi.postoutput
+++ b/mkosi.profiles/gcp/mkosi.postoutput
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu -o pipefail
 

--- a/mkosi.version
+++ b/mkosi.version
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # mkosi doesn't support customizing version script path in config files,

--- a/modules/flashbox/common/mkosi.build
+++ b/modules/flashbox/common/mkosi.build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 source scripts/make_git_package.sh

--- a/modules/flashbox/common/mkosi.postinst
+++ b/modules/flashbox/common/mkosi.postinst
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 # Create users and groups

--- a/modules/flashbox/common/unmask-systemd.sh
+++ b/modules/flashbox/common/unmask-systemd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Additional systemd units to enable for proper reboot support in bob-common

--- a/modules/flashbox/flashbox-l1/mkosi.build
+++ b/modules/flashbox/flashbox-l1/mkosi.build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 source scripts/make_git_package.sh

--- a/modules/flashbox/flashbox-l1/mkosi.postinst
+++ b/modules/flashbox/flashbox-l1/mkosi.postinst
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 # Create user and group

--- a/modules/l2/_common/mkosi.build
+++ b/modules/l2/_common/mkosi.build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 

--- a/modules/l2/_common/mkosi.postinst.chroot
+++ b/modules/l2/_common/mkosi.postinst.chroot
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 

--- a/modules/l2/_common/mkosi.sync
+++ b/modules/l2/_common/mkosi.sync
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ ! -f "$SRCDIR/mkosi.packages/fluent-bit.deb" ]; then
     curl -sSfL https://packages.fluentbit.io/debian/bookworm/fluent-bit_3.1.6_amd64.deb -o "$SRCDIR/mkosi.packages/fluent-bit.deb"

--- a/modules/l2/_devtools_no_console/mkosi.postinst.chroot
+++ b/modules/l2/_devtools_no_console/mkosi.postinst.chroot
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 

--- a/modules/l2/_devtools_no_root_login/mkosi.postinst.chroot
+++ b/modules/l2/_devtools_no_root_login/mkosi.postinst.chroot
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 

--- a/modules/l2/_devtools_users/mkosi.postinst.chroot
+++ b/modules/l2/_devtools_users/mkosi.postinst.chroot
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 

--- a/modules/l2/_gcp/mkosi.postinst.chroot
+++ b/modules/l2/_gcp/mkosi.postinst.chroot
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 

--- a/modules/l2/op-rbuilder-bproxy/mkosi.build
+++ b/modules/l2/op-rbuilder-bproxy/mkosi.build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 

--- a/modules/l2/op-rbuilder-bproxy/mkosi.postinst.chroot
+++ b/modules/l2/op-rbuilder-bproxy/mkosi.postinst.chroot
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 

--- a/modules/l2/op-rbuilder/mkosi.build
+++ b/modules/l2/op-rbuilder/mkosi.build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 

--- a/modules/l2/op-rbuilder/mkosi.postinst.chroot
+++ b/modules/l2/op-rbuilder/mkosi.postinst.chroot
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 

--- a/modules/l2/simulator/mkosi.build
+++ b/modules/l2/simulator/mkosi.build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 

--- a/modules/l2/simulator/mkosi.postinst.chroot
+++ b/modules/l2/simulator/mkosi.postinst.chroot
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 

--- a/modules/tdx-dummy/mkosi.build
+++ b/modules/tdx-dummy/mkosi.build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 source scripts/make_git_package.sh

--- a/modules/tdx-dummy/mkosi.postinst
+++ b/modules/tdx-dummy/mkosi.postinst
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 # Install systemd service units

--- a/scripts/build_rust_package.sh
+++ b/scripts/build_rust_package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 build_rust_package() {
     local package="$1"

--- a/scripts/make_git_package.sh
+++ b/scripts/make_git_package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Note env variables: DESTDIR, BUILDROOT, GOCACHE, BUILDDIR
 

--- a/scripts/unpack_image.sh
+++ b/scripts/unpack_image.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 usage() {

--- a/shared/mkosi.build.d/10-kernel.sh
+++ b/shared/mkosi.build.d/10-kernel.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 shopt -s inherit_errexit  # propagate errexit to $() subshells
 shopt -s nullglob         # non-matching globs expand to nothing

--- a/shared/mkosi.finalize.d/10-remove-image-version.sh
+++ b/shared/mkosi.finalize.d/10-remove-image-version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # mkosi adds IMAGE_VERSION tag to /usr/lib/os-release, if it's set.

--- a/shared/mkosi.finalize.d/90-debloat.sh
+++ b/shared/mkosi.finalize.d/90-debloat.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Ensure deterministic ordering of uid and gids before debloating

--- a/shared/mkosi.postinst.d/10-efi-stub.sh
+++ b/shared/mkosi.postinst.d/10-efi-stub.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Use a version of systemd-boot that is compatible with measured-boot script

--- a/shared/mkosi.postinst.d/90-debloat-systemd.sh
+++ b/shared/mkosi.postinst.d/90-debloat-systemd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Core systemd units to keep

--- a/shared/mkosi.sync.d/10-setup-apt.sh
+++ b/shared/mkosi.sync.d/10-setup-apt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Adds mkosi sources. See https://github.com/systemd/mkosi/issues/1755
 SNAPSHOT=$(jq -r .Snapshot /work/config.json)

--- a/shared/mkosi.sync.d/20-normalize-umask.sh
+++ b/shared/mkosi.sync.d/20-normalize-umask.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 chmod -cR go-w "$SRCDIR"


### PR DESCRIPTION
This PR has some changes i needed to get this to build locally on nixos without lima. 

The shell scripts in this repo assume bash is located at `/bin/bash` which isn't always the case.  This PR switches them to use `/usr/bin/env bash` which is more universal.

This also adds some basic tools to the `flake.nix` developer shell which are needed by the build: `bash`, `curl`, `git` and `jq`.   