### PR TITLE
chore: memory optimizations

### DIFF
--- a/modules/flashbox/flashbox-l1/mkosi.build
+++ b/modules/flashbox/flashbox-l1/mkosi.build
@@ -12,7 +12,7 @@ LIGHTHOUSE_BUILD_CMD="
     export RUSTFLAGS='-C link-arg=-Wl,--build-id=none -C metadata= --remap-path-prefix \$(pwd)=. -L /usr/lib/x86_64-linux-gnu -l z -l zstd -l snappy'
 
     cargo build --bin lighthouse \
-        --features gnosis,slasher-lmdb,slasher-mdbx,slasher-redb,sysmalloc \
+        --features gnosis,slasher-lmdb,slasher-mdbx,slasher-redb,jemalloc-unprefixed \
         --profile release \
         --locked \
         --target x86_64-unknown-linux-gnu

--- a/modules/flashbox/flashbox-l1/mkosi.extra/etc/systemd/system/lighthouse.service
+++ b/modules/flashbox/flashbox-l1/mkosi.extra/etc/systemd/system/lighthouse.service
@@ -20,6 +20,7 @@ ExecStart=/usr/bin/lighthouse bn \
 		--datadir "/persistent/lighthouse" \
         --disable-optimistic-finalized-sync \
         --disable-quic \
+        --state-cache-size 32 \
         --logfile-dir /persistent/lighthouse_logs \
         --logfile-format JSON \
         --logfile-debug-level debug \

--- a/shared/mkosi.conf
+++ b/shared/mkosi.conf
@@ -19,7 +19,7 @@ Seed=630b5f72-a36a-4e83-b23d-6ef47c82fd9c
 
 [Content]
 SourceDateEpoch=0
-KernelCommandLine=console=tty0 console=ttyS0,115200n8 mitigations=auto,nosmt spec_store_bypass_disable=on nospectre_v2 systemd.unit=minimal.target
+KernelCommandLine=console=tty0 console=ttyS0,115200n8 mitigations=auto,nosmt spec_store_bypass_disable=on nospectre_v2 transparent_hugepage=madvise systemd.unit=minimal.target
 ExtraTrees=shared/mkosi.extra
 BuildScripts=shared/mkosi.build.d/*
 SyncScripts=shared/mkosi.sync.d/*


### PR DESCRIPTION
This pull request introduces several configuration changes to improve memory management and performance for the Lighthouse service. The most significant updates include enabling transparent huge pages, adjusting the state cache size, and switching the memory allocator in the build process.

**Performance and Memory Management:**

* Enabled transparent huge pages by adding `transparent_hugepage=madvise` to the kernel command line in `shared/mkosi.conf`, which can improve memory usage efficiency.
* Set the Lighthouse state cache size to 32 by adding `--state-cache-size 32` to the systemd service configuration in `modules/flashbox/flashbox-l1/mkosi.extra/etc/systemd/system/lighthouse.service`.

**Build Process:**

* Switched the memory allocator feature from `sysmalloc` to `jemalloc-unprefixed` in the Lighthouse build command in `modules/flashbox/flashbox-l1/mkosi.build`, which may enhance performance and reduce memory fragmentation.