### PR TITLE
Bump kernel to 6.19 + Debian snapshot 20260430 to fix CVE-2026-31431

### DIFF
--- a/images/flashbox-l1.conf
+++ b/images/flashbox-l1.conf
@@ -7,4 +7,4 @@ Include=modules/flashbox/flashbox-l1/mkosi.conf
 Profiles=azure,gcp
 
 [Distribution]
-Snapshot=20260301T083349Z
+Snapshot=20260430T025253Z

--- a/images/flashbox-l2.conf
+++ b/images/flashbox-l2.conf
@@ -7,4 +7,4 @@ Include=modules/flashbox/flashbox-l2/mkosi.conf
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260301T083349Z
+Snapshot=20260430T025253Z

--- a/images/l2-op-rbuilder-bproxy.conf
+++ b/images/l2-op-rbuilder-bproxy.conf
@@ -2,7 +2,7 @@
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260301T083349Z
+Snapshot=20260430T025253Z
 
 [Include]
 Include=shared/mkosi.conf

--- a/images/l2-op-rbuilder.conf
+++ b/images/l2-op-rbuilder.conf
@@ -2,7 +2,7 @@
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260301T083349Z
+Snapshot=20260430T025253Z
 
 [Include]
 Include=shared/mkosi.conf

--- a/images/l2-simulator.conf
+++ b/images/l2-simulator.conf
@@ -2,7 +2,7 @@
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260301T083349Z
+Snapshot=20260430T025253Z
 
 [Include]
 Include=shared/mkosi.conf

--- a/shared/mkosi.conf
+++ b/shared/mkosi.conf
@@ -6,7 +6,7 @@ Release=trixie
 [Build]
 PackageCacheDirectory=mkosi.cache
 SandboxTrees=mkosi.builddir/mkosi.sources:/etc/apt/sources.list.d/mkosi.sources
-Environment=KERNEL_VERSION=6.18
+Environment=KERNEL_VERSION=6.19
             KERNEL_CONFIG_SNIPPETS=shared/kernel/config.d
             KERNEL_PATCHES=shared/kernel/patches
 WithNetwork=true


### PR DESCRIPTION
Pulls in Debian's linux-source-6.19_6.19.13-1~bpo13+1 from trixie-backports, which carries upstream a664bf3d603d ('crypto: algif_aead - Revert to operating out-of-place') and its authencesn follow-up. trixie's 6.18 line is still listed as vulnerable on the security tracker.

Refs:
- https://security-tracker.debian.org/tracker/CVE-2026-31431
- https://snapshot.debian.org/package/linux/6.19.13-1~bpo13%2B1/
- https://metadata.ftp-master.debian.org/changelogs//main/l/linux/linux_6.19.13-1~bpo13+1_changelog (line 168)
- https://git.kernel.org/linus/a664bf3d603dc3bdcf9ae47cc21e0daec706d7a5