### PR TITLE
Move needed network deps to shared module

### DIFF
--- a/mkosi.profiles/gcp/mkosi.conf
+++ b/mkosi.profiles/gcp/mkosi.conf
@@ -5,7 +5,5 @@ Environment=KERNEL_CONFIG_SNIPPETS_GCP=mkosi.profiles/gcp/kernel/config.d
 [Content]
 ExtraTrees=mkosi.extra
 
-Packages=udev
-         chrony
-         nvme-cli
+Packages=nvme-cli
          xxd

--- a/modules/flashbox/common/mkosi.conf
+++ b/modules/flashbox/common/mkosi.conf
@@ -27,7 +27,6 @@ Packages=podman
          libdevmapper1.02.1
          libjson-c5
          openssh-sftp-server
-         udev
          libsnappy1v5
 
 BuildPackages=build-essential

--- a/shared/mkosi.conf
+++ b/shared/mkosi.conf
@@ -41,6 +41,7 @@ Packages=kmod
          iproute2
          e2fsprogs
          chrony
+         udev
 BuildPackages=build-essential
               git
               curl


### PR DESCRIPTION
udev is needed for network to work on all platforms, so i added it to the shared module rather than the GCP module. I also removed a duplicate chrony package config line in the gcp mkosi.conf which was next to the no longer needed udev line.