### PR TITLE
[WIP] L2 Builder Uni: Trim redundant fields from rsyslog JSON envelope

### DIFF
--- a/modules/l2/_common/mkosi.extra/etc/rsyslog.d/01-json-template.conf
+++ b/modules/l2/_common/mkosi.extra/etc/rsyslog.d/01-json-template.conf
@@ -8,11 +8,8 @@ template(name="json-event-json-msg"
   type="list") {
     constant(value="{")
       constant(value="\"@timestamp\":\"")     property(name="timereported" dateFormat="rfc3339")
-      constant(value="\",\"sysloghost\":\"")  property(name="hostname")
-      constant(value="\",\"procid\":\"")      property(name="procid")
-      constant(value="\",\"facility\":\"")    property(name="syslogfacility-text")
-      constant(value="\",\"severity\":\"")    property(name="syslogseverity-text")
       constant(value="\",\"source\":\"")      property(name="programname")
+      constant(value="\",\"procid\":\"")      property(name="procid")
       constant(value="\",\"message\":")       property(name="msg" position.from="2")
     constant(value="}\n")
 }
@@ -27,11 +24,8 @@ template(name="json-event-string-msg"
   type="list") {
     constant(value="{")
       constant(value="\"@timestamp\":\"")     property(name="timereported" dateFormat="rfc3339")
-      constant(value="\",\"sysloghost\":\"")  property(name="hostname")
-      constant(value="\",\"procid\":\"")      property(name="procid")
-      constant(value="\",\"facility\":\"")    property(name="syslogfacility-text")
-      constant(value="\",\"severity\":\"")    property(name="syslogseverity-text")
       constant(value="\",\"source\":\"")      property(name="programname")
+      constant(value="\",\"procid\":\"")      property(name="procid")
       constant(value="\",\"message\":\"")     property(name="msg" format="json" position.from="2")
     constant(value="\"}\n")
 }


### PR DESCRIPTION
## Summary

Removes 3 redundant fields from rsyslog JSON envelope templates (`sysloghost`, `severity`, `facility`). All live mainnet builder logs carry these duplications:

- **Hostname (2x):** `jsonPayload.sysloghost` duplicates `labels.compute.googleapis.com/resource_name`
- **Severity (2x):** `jsonPayload.severity` always reports `info` regardless of actual app log level. Misleading and duplicated by `jsonPayload.message.level`
- **Facility:** always "daemon"

----

AI generated:
```
  ┌─────────────┬───────────────┬──────────────┬─────────┐
  │   Source    │ Avg line size │ Removed/line │ Savings │
  ├─────────────┼───────────────┼──────────────┼─────────┤
  │ bproxy      │ 718 bytes     │ 90 bytes     │ 12.5%   │
  ├─────────────┼───────────────┼──────────────┼─────────┤
  │ op-rbuilder │ 462 bytes     │ 90 bytes     │ 19.5%   │
  └─────────────┴───────────────┴──────────────┴─────────┘

 ~90 bytes removed is constant. Percentage depends on how fat the line is: short op-rbuilder lines 
 save more proportionally, longer bproxy lines save less.
 
 ```