### PR TITLE
Switch kernel to 6.12 LTS + Debian snapshot 20260519

### DIFF
--- a/images/flashbox-l1.conf
+++ b/images/flashbox-l1.conf
@@ -7,4 +7,4 @@ Include=modules/flashbox/flashbox-l1/mkosi.conf
 Profiles=azure,gcp
 
 [Distribution]
-Snapshot=20260430T025253Z
+Snapshot=20260519T000413Z

--- a/images/flashbox-l2.conf
+++ b/images/flashbox-l2.conf
@@ -7,4 +7,4 @@ Include=modules/flashbox/flashbox-l2/mkosi.conf
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260430T025253Z
+Snapshot=20260519T000413Z

--- a/images/l2-op-rbuilder-bproxy.conf
+++ b/images/l2-op-rbuilder-bproxy.conf
@@ -2,7 +2,7 @@
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260430T025253Z
+Snapshot=20260519T000413Z
 
 [Include]
 Include=shared/mkosi.conf

--- a/images/l2-op-rbuilder.conf
+++ b/images/l2-op-rbuilder.conf
@@ -2,7 +2,7 @@
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260430T025253Z
+Snapshot=20260519T000413Z
 
 [Include]
 Include=shared/mkosi.conf

--- a/images/l2-simulator.conf
+++ b/images/l2-simulator.conf
@@ -2,7 +2,7 @@
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260430T025253Z
+Snapshot=20260519T000413Z
 
 [Include]
 Include=shared/mkosi.conf

--- a/shared/mkosi.build.d/10-kernel.sh
+++ b/shared/mkosi.build.d/10-kernel.sh
@@ -73,7 +73,7 @@ else
     kernel_src_dir="${BUILDROOT}${chroot_kernel_src_dir}"
     kconfig_dir="${BUILDROOT}${chroot_kconfig_dir}"
 
-    apt-get -y install "linux-source-${KERNEL_VERSION}/${release}-backports" --install-recommends
+    apt-get -y install "linux-source-${KERNEL_VERSION}" --install-recommends
 
     source_tarball="${BUILDROOT}/usr/src/linux-source-${KERNEL_VERSION}.tar.xz"
     if [[ ! -f "${source_tarball}" ]]; then

--- a/shared/mkosi.conf
+++ b/shared/mkosi.conf
@@ -6,7 +6,7 @@ Release=trixie
 [Build]
 PackageCacheDirectory=mkosi.cache
 SandboxTrees=mkosi.builddir/mkosi.sources:/etc/apt/sources.list.d/mkosi.sources
-Environment=KERNEL_VERSION=6.19
+Environment=KERNEL_VERSION=6.12
             KERNEL_CONFIG_SNIPPETS=shared/kernel/config.d
             KERNEL_PATCHES=shared/kernel/patches
 WithNetwork=true

--- a/shared/mkosi.sync.d/10-setup-apt.sh
+++ b/shared/mkosi.sync.d/10-setup-apt.sh
@@ -4,14 +4,22 @@
 SNAPSHOT=$(jq -r .Snapshot /work/config.json)
 if [ "$SNAPSHOT" = "null" ]; then
     MIRROR="http://deb.debian.org/debian"
+    MIRROR_SECURITY="http://security.debian.org/debian-security"
 else
     MIRROR="http://snapshot.debian.org/archive/debian/${SNAPSHOT}"
+    MIRROR_SECURITY="http://snapshot.debian.org/archive/debian-security/${SNAPSHOT}"
 fi
 
 cat > "$SRCDIR/mkosi.builddir/mkosi.sources" <<EOF
 Types: deb deb-src
 URIs: $MIRROR
 Suites: ${RELEASE} ${RELEASE}-backports
+Components: main
+Trusted: yes
+
+Types: deb deb-src
+URIs: $MIRROR_SECURITY
+Suites: ${RELEASE}-security
 Components: main
 Trusted: yes
 EOF


### PR DESCRIPTION
Security hardening and snapshot refresh. Linux 6.19 is upstream EOL. Move to the 6.12 LTS line via the trixie-security pocket, which carries Debian-backported fixes for four recent kernel CVEs:

  - CVE-2026-31431 (copy.fail / algif_aead) -- crypto: algif_aead - Revert to operating out-of-place (in 6.12.85-1).
  - CVE-2026-46300 (Fragnesia / XFRM ESP-in-TCP) -- xfrm: esp: avoid in-place decrypt on shared skb frags (Debian cherry-pick added in 6.12.86-1).
  - "Dirty Frag" / Copy Fail 2 -- same xfrm-esp shared-frag series; covered by the same cherry-pick.
  - CVE-2026-46333 (ssh-keysign-pwn / __ptrace_may_access dumpable) -- ptrace: slightly saner 'get_dumpable()' logic (in 6.12.88-1).

Resulting package: linux 6.12.88-1 from trixie-security.
Snapshot:          20260519T000413Z (latest debian-security snapshot
                   confirmed to contain 6.12.88-1; same timestamp
                   resolves on the main debian archive).

Changes:

  - shared/mkosi.conf: KERNEL_VERSION 6.19 -> 6.12.
  - shared/mkosi.build.d/10-kernel.sh: drop the /trixie-backports suite pin from the apt-get install; 6.12 lives in main + security, not backports.
  - shared/mkosi.sync.d/10-setup-apt.sh: emit a second sources block for trixie-security (snapshot mirror archive/debian-security/, or security.debian.org for unpinned builds).
  - images/{flashbox-l1,flashbox-l2,l2-op-rbuilder,l2-op-rbuilder-bproxy, l2-simulator}.conf: Snapshot bumped to 20260519T000413Z.

References:
  https://snapshot.debian.org/package/linux/6.12.88-1/
  https://snapshot.debian.org/archive/debian-security/20260519T000413Z/