### PR TITLE
fix: use `systemd-repart` from nix

### DIFF
--- a/mkosi.profiles/gcp/mkosi.postoutput
+++ b/mkosi.profiles/gcp/mkosi.postoutput
@@ -21,7 +21,14 @@ cp mkosi.profiles/gcp/repart.d/00-uki.conf "${REPART_TMPDIR}/00-uki.conf"
 echo "SizeMinBytes=${ESP_BYTES}" >> "${REPART_TMPDIR}/00-uki.conf"
 echo "SizeMaxBytes=${ESP_BYTES}" >> "${REPART_TMPDIR}/00-uki.conf"
 
-systemd-repart --empty=create \
+#
+# - default systemd-repart (in /usr/bin) is "systemd 252 (252.39-1~deb12u2)"
+# - the one from nix (/nix/store/*-systemd-*/bin) is newer ("systemd 258 (258.3)" a.t.m.)
+# - to use "--copy-source" CLI option we need a newer one
+# - this hack ensures systemd-repart resolves to the nix one
+#
+PATH="${PATH#/usr/bin:/usr/sbin:}" systemd-repart \
+  --empty=create \
   --size=${DISK_GIB}G \
   --definitions="${REPART_TMPDIR}" \
   --copy-source=${OUTPUTDIR} \


### PR DESCRIPTION
- default `systemd-repart` (in `/usr/bin`) is "systemd 252 (252.39-1~deb12u2)"
- the one from nix (`/nix/store/*-systemd-*/bin`) is newer ("systemd 258 (258.3)" a.t.m.)
- to use `--copy-source` CLI option we need a newer one
- this hack ensures `systemd-repart` resolves to the nix one
