### PR TITLE
flashbox-l1: trim lighthouse resource footprint via flags

### DIFF
--- a/modules/flashbox/flashbox-l1/mkosi.extra/etc/systemd/system/lighthouse.service
+++ b/modules/flashbox/flashbox-l1/mkosi.extra/etc/systemd/system/lighthouse.service
@@ -21,6 +21,13 @@ ExecStart=/usr/bin/lighthouse bn \
         --disable-optimistic-finalized-sync \
         --disable-quic \
         --state-cache-size 32 \
+        --prune-payloads true \
+        --prune-blobs true \
+        --hdiff-buffer-cache-size 1 \
+        --epochs-per-migration 4 \
+        --target-peers 50 \
+        --disable-light-client-server \
+        --disable-upnp \
         --logfile-dir /persistent/lighthouse_logs \
         --logfile-format JSON \
         --logfile-debug-level debug \


### PR DESCRIPTION
The L1 beacon node only needs to drive the searcher's EL via the Engine API (forkchoice). It has no attached validators, serves no REST consumers, proposes no blocks, and does not need to serve historical state/blobs or light-client data to peers. Tune flags to that reality.

Add to lighthouse.service ExecStart:
- --target-peers 50: default is 200; the node only follows head, so cut gossip-validation CPU, bandwidth, and per-connection memory while keeping a healthy head-following margin.
- --disable-light-client-server: LC server is on by default; we don't serve light clients.
- --disable-upnp: no UPnP gateway exists in the TEE/cloud environment.
- --hdiff-buffer-cache-size 1: default 16; each buffer ~ one BeaconState and is irrelevant for a pruning node, so cap the RAM ceiling.
- --epochs-per-migration 4: default 1; batch hot->cold migration to reduce disk writes.
- --prune-payloads true / --prune-blobs true: already the v8.1.3 defaults, set explicitly to document the minimal-footprint intent.

Left --beacon-processor-max-workers at default so it auto-scales to the CVM's vCPU budget (a deploy-time decision, not baked into the image).

Verified against a locally-built lighthouse v8.1.3 (the version pinned in mkosi.build): the exact full ExecStart is accepted by clap and boots into runtime. End-to-end Engine API drive was not exercised.