### PR TITLE
flashbox-l1: allowlist BuilderNet bottom-of-block endpoints

### DIFF
--- a/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/firewall-config
+++ b/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/firewall-config
@@ -32,6 +32,27 @@ FLASHBOTS_BUNDLE_2="3.15.88.156"
 FLASHBOTS_TX_STREAM_1="3.136.107.142"
 FLASHBOTS_TX_STREAM_2="3.149.14.12"
 
+# BuilderNet endpoints (production only) -- TEMPORARY test allowlist
+#
+# Unlike Flashbots/Titan, these IPs serve BOTH the tx stream (persistent wss on
+# path /bob) and bundle submission (bare path) over the same HTTPS endpoint, so
+# they cannot be split into an always-on bundle rule + production-only tx stream
+# rule. Because tx stream is an observable side channel, the whole set is gated
+# to production mode and torn down on toggle (see toggle-config PRODUCTION_ENDPOINTS).
+#
+# Tradeoff: BuilderNet bundle submission only works in production mode, unlike
+# the Flashbots/Titan bundle endpoints which are always on.
+#
+# Searchers must connect by hostname for TLS; static /etc/hosts entries live in
+# searcher-container-after-init. Long term searchers should use rpc.buildernet.org;
+# IPs may change and ideally would not be hardcoded, but production mode has no DNS.
+BUILDERNET_FB_USE4="34.85.211.230"     # fb-gcp-use4-00              (US east, test target)
+BUILDERNET_FB_USE1="200.225.47.181"    # fb-om-use1-00               (US east)
+BUILDERNET_NM_USE="34.150.234.122"     # nethermind-gcp-eastus-101   (US east)
+BUILDERNET_FB_EUW4="34.12.189.183"     # fb-gcp-euw4-00              (EU west)
+BUILDERNET_NM_EUW="34.91.129.156"      # nethermind-gcp-westeurope   (EU west)
+BUILDERNET_FB_ANE1="34.104.157.101"    # fb-gcp-ane1-00              (AP northeast)
+
 # Prometheus metrics proxy
 PROMETHEUS_PROXY_IP="10.88.0.100"
 
@@ -119,3 +140,6 @@ accept_dst_port $CHAIN_MAINTENANCE_OUT udp $EL_P2P_PORT "EL P2P (UDP)"
 
 accept_dst_ip_port $CHAIN_PRODUCTION_OUT tcp $TITAN_IP $TITAN_STATE_DIFF_PORT "Titan state diff WSS"
 accept_dst_ip_port $CHAIN_PRODUCTION_OUT tcp $FLASHBOTS_TX_STREAM_1,$FLASHBOTS_TX_STREAM_2 $HTTPS_PORT "Flashbots Protect tx stream"
+
+# BuilderNet tx stream (path /bob) + bundle submission (bare path), same HTTPS endpoint
+accept_dst_ip_port $CHAIN_PRODUCTION_OUT tcp $BUILDERNET_FB_USE4,$BUILDERNET_FB_USE1,$BUILDERNET_NM_USE,$BUILDERNET_FB_EUW4,$BUILDERNET_NM_EUW,$BUILDERNET_FB_ANE1 $HTTPS_PORT "BuilderNet tx stream + bundle submission"

--- a/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/firewall-config
+++ b/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/firewall-config
@@ -32,26 +32,24 @@ FLASHBOTS_BUNDLE_2="3.15.88.156"
 FLASHBOTS_TX_STREAM_1="3.136.107.142"
 FLASHBOTS_TX_STREAM_2="3.149.14.12"
 
-# BuilderNet endpoints (production only) -- TEMPORARY test allowlist
+# BuilderNet endpoints (production only)
 #
-# Unlike Flashbots/Titan, these IPs serve BOTH the tx stream (persistent wss on
-# path /bob) and bundle submission (bare path) over the same HTTPS endpoint, so
-# they cannot be split into an always-on bundle rule + production-only tx stream
-# rule. Because tx stream is an observable side channel, the whole set is gated
-# to production mode and torn down on toggle (see toggle-config PRODUCTION_ENDPOINTS).
+# These IPs serve BOTH the tx stream (persistent wss on path /bob) and bundle
+# submission (bare path) over the same HTTPS endpoint, so they are not split into
+# an always-on bundle rule + production-only tx stream rule the way the
+# Flashbots/Titan endpoints are. Because tx stream is an observable side channel,
+# the whole set is gated to production mode and torn down on toggle (see
+# toggle-config PRODUCTION_ENDPOINTS). Consequently BuilderNet bundle submission
+# works only in production mode, unlike the always-on Flashbots/Titan bundles.
 #
-# Tradeoff: BuilderNet bundle submission only works in production mode, unlike
-# the Flashbots/Titan bundle endpoints which are always on.
-#
-# Searchers must connect by hostname for TLS; static /etc/hosts entries live in
-# searcher-container-after-init. Long term searchers should use rpc.buildernet.org;
-# IPs may change and ideally would not be hardcoded, but production mode has no DNS.
-BUILDERNET_FB_USE4="34.85.211.230"     # fb-gcp-use4-00              (US east, test target)
-BUILDERNET_FB_USE1="200.225.47.181"    # fb-om-use1-00               (US east)
-BUILDERNET_NM_USE="34.150.234.122"     # nethermind-gcp-eastus-101   (US east)
-BUILDERNET_FB_EUW4="34.12.189.183"     # fb-gcp-euw4-00              (EU west)
-BUILDERNET_NM_EUW="34.91.129.156"      # nethermind-gcp-westeurope   (EU west)
-BUILDERNET_FB_ANE1="34.104.157.101"    # fb-gcp-ane1-00              (AP northeast)
+# Production mode has no DNS, so these are addressed by IP; the hostnames searchers
+# connect to (for TLS) are mapped statically in searcher-container-after-init.
+BUILDERNET_FB_USE4="34.85.211.230"     # fb-gcp-use4-00            (US east)
+BUILDERNET_FB_USE1="200.225.47.181"    # fb-om-use1-00             (US east)
+BUILDERNET_NM_USE="34.150.234.122"     # nethermind-gcp-eastus-101 (US east)
+BUILDERNET_FB_EUW4="34.12.189.183"     # fb-gcp-euw4-00            (EU west)
+BUILDERNET_NM_EUW="34.91.129.156"      # nethermind-gcp-westeurope (EU west)
+BUILDERNET_FB_ANE1="34.104.157.101"    # fb-gcp-ane1-00            (AP northeast)
 
 # Prometheus metrics proxy
 PROMETHEUS_PROXY_IP="10.88.0.100"

--- a/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/searcher-container-after-init
+++ b/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/searcher-container-after-init
@@ -10,13 +10,10 @@ exec_in_container '
 3.15.88.156   backruns.tee-searcher.flashbots.net
 52.207.17.217 fbtee.titanbuilder.xyz
 
-# BuilderNet -- TEMPORARY test allowlist. Searchers connect by hostname so TLS
-# validates (production mode has no DNS). The test runs against the first IP
-# (fb-gcp-use4-00). US nodes are listed first for latency.
-#
-# NOTE: mapping all IPs to rpc.buildernet.org here loses the BuilderNet LB
-# health checks (rpc normally returns only healthy IPs); failover is dial-level,
-# not health-aware. Acceptable for testing; revisit before continuous production use.
+# BuilderNet. Searchers connect by hostname so TLS validates (production mode has
+# no DNS). US nodes are listed first for latency. Mapping all IPs to
+# rpc.buildernet.org here means failover is dial-level (next IP on connect
+# failure), not health-aware like the BuilderNet load balancer.
 34.85.211.230  fb-gcp-use4-00.nodes.buildernet.org direct-us.buildernet.org rpc.buildernet.org
 200.225.47.181 fb-om-use1-00.nodes.buildernet.org direct-us.buildernet.org rpc.buildernet.org
 34.150.234.122 nethermind-gcp-eastus-101.nodes.buildernet.org direct-us.buildernet.org rpc.buildernet.org

--- a/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/searcher-container-after-init
+++ b/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/searcher-container-after-init
@@ -9,4 +9,18 @@ exec_in_container '
 18.221.59.61  backruns.tee-searcher.flashbots.net
 3.15.88.156   backruns.tee-searcher.flashbots.net
 52.207.17.217 fbtee.titanbuilder.xyz
+
+# BuilderNet -- TEMPORARY test allowlist. Searchers connect by hostname so TLS
+# validates (production mode has no DNS). The test runs against the first IP
+# (fb-gcp-use4-00). US nodes are listed first for latency.
+#
+# NOTE: mapping all IPs to rpc.buildernet.org here loses the BuilderNet LB
+# health checks (rpc normally returns only healthy IPs); failover is dial-level,
+# not health-aware. Acceptable for testing; revisit before continuous production use.
+34.85.211.230  fb-gcp-use4-00.nodes.buildernet.org direct-us.buildernet.org rpc.buildernet.org
+200.225.47.181 fb-om-use1-00.nodes.buildernet.org direct-us.buildernet.org rpc.buildernet.org
+34.150.234.122 nethermind-gcp-eastus-101.nodes.buildernet.org direct-us.buildernet.org rpc.buildernet.org
+34.12.189.183  fb-gcp-euw4-00.nodes.buildernet.org direct-eu.buildernet.org rpc.buildernet.org
+34.91.129.156  nethermind-gcp-westeurope-100.nodes.buildernet.org direct-eu.buildernet.org rpc.buildernet.org
+34.104.157.101 fb-gcp-ane1-00.nodes.buildernet.org direct-ap.buildernet.org rpc.buildernet.org
 EOF'

--- a/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/toggle-config
+++ b/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/toggle-config
@@ -12,7 +12,7 @@ PRODUCTION_ENDPOINTS=(
     "52.207.17.217:Titan state diff"
     "3.136.107.142:Flashbots protect tx"
     "3.149.14.12:Flashbots protect tx"
-    # BuilderNet (tx stream + bundle submission share these IPs) -- TEMPORARY test allowlist
+    # BuilderNet (tx stream + bundle submission share these IPs)
     "34.85.211.230:BuilderNet fb-gcp-use4-00"
     "200.225.47.181:BuilderNet fb-om-use1-00"
     "34.150.234.122:BuilderNet nethermind-eastus"

--- a/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/toggle-config
+++ b/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/toggle-config
@@ -6,10 +6,19 @@
 IMAGE_TYPE="bob-l1"
 
 # Production endpoints (format: "IP:Description")
+# Established flows to these IPs are killed via conntrack when leaving production
+# mode, so the tx-stream side channel does not survive into maintenance mode.
 PRODUCTION_ENDPOINTS=(
     "52.207.17.217:Titan state diff"
     "3.136.107.142:Flashbots protect tx"
     "3.149.14.12:Flashbots protect tx"
+    # BuilderNet (tx stream + bundle submission share these IPs) -- TEMPORARY test allowlist
+    "34.85.211.230:BuilderNet fb-gcp-use4-00"
+    "200.225.47.181:BuilderNet fb-om-use1-00"
+    "34.150.234.122:BuilderNet nethermind-eastus"
+    "34.12.189.183:BuilderNet fb-gcp-euw4-00"
+    "34.91.129.156:BuilderNet nethermind-westeurope"
+    "34.104.157.101:BuilderNet fb-gcp-ane1-00"
 )
 
 # Maintenance ports (format: "protocol:port:description")


### PR DESCRIPTION
Add a temporary egress allowlist for the new BuilderNet bottom-of-block endpoints so a searcher can connect to a specific pre-configured builder instance for testing.

These 6 IPs serve both the tx stream (persistent wss, path /bob) and bundle submission (bare path) over the same HTTPS endpoint, so they cannot be split into an always-on bundle rule + production-only tx stream rule the way the Flashbots/Titan endpoints are. Since tx stream is an observable side channel, the whole set is gated to production mode.

- firewall-config: add 6 BuilderNet IPs to PRODUCTION_OUT (HTTPS/443)
- toggle-config: add the same IPs to PRODUCTION_ENDPOINTS so tx-stream flows are torn down via conntrack when leaving production mode
- searcher-container-after-init: add static /etc/hosts entries (US nodes first) so the searcher connects by hostname and TLS validates without DNS

Tradeoff: BuilderNet bundle submission only works in production mode, unlike the Flashbots/Titan bundle endpoints which are always on.