### PR TITLE
flashbox-l1: drop BuilderNet endpoints in maintenance mode

### DIFF
--- a/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/firewall-config
+++ b/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/firewall-config
@@ -116,6 +116,9 @@ accept_dst_port $CHAIN_MAINTENANCE_IN udp $EL_P2P_PORT "EL P2P (UDP)"
 # Block Flashbots protect tx endpoints during maintenance
 drop_dst_ip $CHAIN_MAINTENANCE_OUT $FLASHBOTS_TX_STREAM_1,$FLASHBOTS_TX_STREAM_2 "Flashbots Protect (DROP before accept-all rules)"
 
+# Block BuilderNet endpoints during maintenance. 
+drop_dst_ip $CHAIN_MAINTENANCE_OUT $BUILDERNET_FB_USE4,$BUILDERNET_FB_USE1,$BUILDERNET_NM_USE,$BUILDERNET_FB_EUW4,$BUILDERNET_NM_EUW,$BUILDERNET_FB_ANE1 "BuilderNet (DROP before accept-all rules)"
+
 accept_dst_port $CHAIN_MAINTENANCE_OUT udp $DNS_PORT "DNS (UDP)"
 accept_dst_port $CHAIN_MAINTENANCE_OUT tcp $DNS_PORT "DNS (TCP)"
 accept_dst_port $CHAIN_MAINTENANCE_OUT tcp $DNS_OVER_TLS_PORT "DNS-over-TLS"


### PR DESCRIPTION
BuilderNet IPs are allowlisted in PRODUCTION_OUT and torn down on toggle via toggle-config PRODUCTION_ENDPOINTS, but were missing the MAINTENANCE_OUT drop that the Flashbots tx-stream endpoints already have.

Because MAINTENANCE_OUT accepts HTTPS to any IP (catch-all), the BuilderNet endpoints -- which carry the tx-stream side channel on 443 -- were reachable in maintenance mode, contradicting their production-only intent. Add the drop before the accept-all rules, mirroring the Flashbots Protect tx-stream treatment.

flashbox-l2 reviewed: it has no BuilderNet endpoints (production-only egress is the simulator, already dropped in maintenance), so no change needed there.