### PR TITLE
flashbox-l1: remove titan endpoints

### DIFF
--- a/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/firewall-config
+++ b/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/firewall-config
@@ -19,12 +19,6 @@ NTP_NTS_PORT=4460
 CL_P2P_PORT=9000
 EL_P2P_PORT=30303
 
-TITAN_IP="52.207.17.217"
-TITAN_BUNDLE_PORT=1338      # bundle submission (always on)
-TITAN_STATE_DIFF_PORT=42203 # state diff stream (production only)
-# If Titan state diff port ever changes to any of accepted in maintenance,
-# update MAINTENANCE_OUT the same way as for FLASHBOTS_TX_STREAM*
-
 # Flashbots bundle (always on)
 FLASHBOTS_BUNDLE_1="18.221.59.61"
 FLASHBOTS_BUNDLE_2="3.15.88.156"
@@ -37,10 +31,10 @@ FLASHBOTS_TX_STREAM_2="3.149.14.12"
 # These IPs serve BOTH the tx stream (persistent wss on path /bob) and bundle
 # submission (bare path) over the same HTTPS endpoint, so they are not split into
 # an always-on bundle rule + production-only tx stream rule the way the
-# Flashbots/Titan endpoints are. Because tx stream is an observable side channel,
+# Flashbots endpoints are. Because tx stream is an observable side channel,
 # the whole set is gated to production mode and torn down on toggle (see
 # toggle-config PRODUCTION_ENDPOINTS). Consequently BuilderNet bundle submission
-# works only in production mode, unlike the always-on Flashbots/Titan bundles.
+# works only in production mode, unlike the always-on Flashbots bundles.
 #
 # Production mode has no DNS, so these are addressed by IP; the hostnames searchers
 # connect to (for TLS) are mapped statically in searcher-container-after-init.
@@ -83,12 +77,6 @@ accept_dst_port $CHAIN_ALWAYS_OUT udp $CL_P2P_PORT "CL P2P (UDP)"
 # Note: this is accessible only from host, searcher netns has DROP on those
 accept_dst_port $CHAIN_ALWAYS_OUT udp $NTP_PORT "NTP"
 accept_dst_port $CHAIN_ALWAYS_OUT tcp $NTP_NTS_PORT "NTP-NTS"
-
-# Titan builder bundle endpoints (always on)
-# Security note: This is a side channel.
-# While the operator will not be able to see the content of the packets,
-# they can observe the presence or absence of packets.
-accept_dst_ip_port $CHAIN_ALWAYS_OUT tcp $TITAN_IP $TITAN_BUNDLE_PORT "Titan builder bundle"
 
 # Flashbots bundle endpoints (always on)
 # Security note: This is a side channel.
@@ -139,7 +127,6 @@ accept_dst_port $CHAIN_MAINTENANCE_OUT udp $EL_P2P_PORT "EL P2P (UDP)"
 # (6) PRODUCTION_OUT: Outbound rules for Production Mode
 ###########################################################################
 
-accept_dst_ip_port $CHAIN_PRODUCTION_OUT tcp $TITAN_IP $TITAN_STATE_DIFF_PORT "Titan state diff WSS"
 accept_dst_ip_port $CHAIN_PRODUCTION_OUT tcp $FLASHBOTS_TX_STREAM_1,$FLASHBOTS_TX_STREAM_2 $HTTPS_PORT "Flashbots Protect tx stream"
 
 # BuilderNet tx stream (path /bob) + bundle submission (bare path), same HTTPS endpoint

--- a/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/searcher-container-after-init
+++ b/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/searcher-container-after-init
@@ -8,7 +8,6 @@ exec_in_container '
 3.136.107.142 tx.tee-searcher.flashbots.net
 18.221.59.61  backruns.tee-searcher.flashbots.net
 3.15.88.156   backruns.tee-searcher.flashbots.net
-52.207.17.217 fbtee.titanbuilder.xyz
 
 # BuilderNet. Searchers connect by hostname so TLS validates (production mode has
 # no DNS). US nodes are listed first for latency. Mapping all IPs to

--- a/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/toggle-config
+++ b/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/toggle-config
@@ -9,7 +9,6 @@ IMAGE_TYPE="bob-l1"
 # Established flows to these IPs are killed via conntrack when leaving production
 # mode, so the tx-stream side channel does not survive into maintenance mode.
 PRODUCTION_ENDPOINTS=(
-    "52.207.17.217:Titan state diff"
     "3.136.107.142:Flashbots protect tx"
     "3.149.14.12:Flashbots protect tx"
     # BuilderNet (tx stream + bundle submission share these IPs)

--- a/modules/flashbox/flashbox-l1/readme.md
+++ b/modules/flashbox/flashbox-l1/readme.md
@@ -1,7 +1,7 @@
 TEE Searcher
 ===
 
-Using Intel TDX, Flashbots has built a way for searchers to trustlessly backrun transactions with full information, without exposing frontrunning risks. This product is currently live on Ethereum mainnet for searching on Flashbots Protect, Titan Builder's bottom of block, and BuilderNet's bottom of block.
+Using Intel TDX, Flashbots has built a way for searchers to trustlessly backrun transactions with full information, without exposing frontrunning risks. This product is currently live on Ethereum mainnet for searching on Flashbots Protect and BuilderNet's bottom of block.
 
 - [TDX Mental Model](#tdx-mental-model)
 - [Image Overview](#image-overview)
@@ -10,7 +10,6 @@ Using Intel TDX, Flashbots has built a way for searchers to trustlessly backrun 
 - [Attestation Walkthrough](#attestation-walkthrough)
 - [Order Flow APIs](#order-flow-apis)
   - [Flashbots Protect](#searching-on-flashbots-protect-transactions)
-  - [Titan Builder](#searching-on-titan-builders-bottom-of-block)
   - [BuilderNet](#searching-on-buildernets-bottom-of-block)
 - [Disk Persistence](#disk-persistence)
 - [Searcher Commands and Services](#searcher-commands-and-services)
@@ -73,10 +72,8 @@ Firewall Rules
 | 30303 | Input + Output            | Execution Client P2P            | Podman               | TCP + UDP | DISABLED        | ENABLED          |
 | 9000  | Input + Output            | Consensus Client P2P            | Podman               | TCP + UDP | ENABLED         | ENABLED          |
 | 443   | Output **IP WHITELISTED** | Flashbots Protect Tx Stream     | Podman               | TCP       | ENABLED         | DISABLED         |
-| 42203 | Output **IP WHITELISTED** | Titan Builder State Diff Stream | Podman               | TCP       | ENABLED         | DISABLED         |
 | 443   | Output **IP WHITELISTED** | BuilderNet State Diff Stream + Bundle RPC | BuilderNet RPC | TCP   | ENABLED         | DISABLED         |
 | 443   | Output **IP WHITELISTED** | Flashbots Bundle RPC            | Flashbots Bundle RPC | TCP       | ENABLED         | ENABLED          |
-| 1338  | Output **IP WHITELISTED** | Titan Bundle RPC                | Titan Bundle RPC     | TCP       | ENABLED         | ENABLED          |
 | 53    | Output                    | DNS                             | DNS                  | TCP + UDP | DISABLED        | ENABLED          |
 | 80    | Output                    | HTTP                            | HTTP                 | TCP       | DISABLED        | ENABLED          |
 | 443   | Output                    | HTTPS                           | HTTPS                | TCP       | DISABLED        | ENABLED          |
@@ -362,142 +359,9 @@ To submit bundles, connect to the server:
 https://backruns.tee-searcher.flashbots.net
 ```
 
-### Searching on Titan Builder's Bottom of Block
-
-**<u>Subscribing to Titan's State Diff Stream</u>**
-
-**Connecting**
-
-Connect to the server located at:
-```
-wss://fbtee.titanbuilder.xyz:42203
-```
-
-Use the `eth_subscribe` method to subscribe to state diffs:
-
-```json
-{"method":"eth_subscribe","params":["flashbots_stateDiffs"]}
-```
-
-**Response**
-
-```json
-{
-  "jsonrpc": "2.0",
-  "result": "whzoOReHirSJxxF8Z0bqvbghmXjD3hWRW0",
-  "id": 1
-}
-```
-
-You'll start receiving state diffs:
-
-```
-{
-  "jsonrpc": "2.0",
-  "method": "eth_subscription",
-  "params": {
-    "subscription": "whzoOReHirSJxxF8Z0bqvbghmXjD3hWRW0",
-    "result": {
-      "blockNumber": "String",  // hex encoded block number the block builder is currently building for
-      "blockTimestamp": "String",  // hex encoded seconds since the unix epoch
-      "blockUuid": "String",  // a UUID V4 that is used to identify the current block being streamed
-      "stateOverrides": "Object" {  // a nested object of changed addresses to changed storage slot keys and their updated value
-        "address": {
-          "balance": "String"
-          "code": "String"  // ONLY IF CONTRACT IS DEPLOYED IN THIS BLOCK
-          "nonce": "String"
-          "stateDiff": {
-            "<storage slot>": "String"
-          }
-        }
-      }
-    }
-  }
-}
-```
-<details>
-<summary>Example Output</summary>
-
-    ```json
-    2024-12-03 23:46:27,370 - __main__ - INFO - Initializing WebSocket connection to ws://127.0.0.1:8547
-    2024-12-03 23:46:27,375 - __main__ - INFO - Subscribed to state diffs
-    2024-12-03 23:46:27,377 - __main__ - INFO - Subscription response: {"jsonrpc":"2.0","result":"aYF2ehyZ8I4fz3rxkkRiOxtnfFqWosI9HC","id":1}
-    2024-12-03 23:46:33,108 - __main__ - INFO - Parsed state diff: {
-      "jsonrpc": "2.0",
-      "method": "eth_subscription",
-      "params": {
-        "subscription": "aYF2ehyZ8I4fz3rxkkRiOxtnfFqWosI9HC",
-        "result": {
-          "blockNumber": "0x1456624",
-          "blockTimestamp": "0x674f985b",
-          "blockUuid": "b3041804-c0ff-4628-9581-29910f78593e",
-          "stateOverrides": {
-            "0x0000000000a39bb272e79075ade125fd351887ac": {
-              "balance": "0x35c9406dfc78d4448d9",
-              "nonce": "0x1",
-              "stateDiff": {
-                "0xffc5f4bf805d0f20d7ba2d180bf4492e98716db6def51fb60972294b5ba556cf": "0x0000000000000000000000000000000000000000000000000905438e60010000"
-              }
-            },
-            "0x111111111117dc0aa78b770fa6a738034120c302": {
-              "stateDiff": {
-                "0xc0ec8fbf02d70b2873f5a76f503e97bd1b0ca8048ab517fad231214a74ebe459": "0x0000000000000000000000000000000000000000000ebc80f5e0cbee39cca338",
-                "0xcb4547a880ed764ae6e3838e74f0795915d3b91357e4852c97ce6e0cdcf6c023": "0x0000000000000000000000000000000000000000000000000000000000000000"
-              }
-            },
-            "0x1a44076050125825900e736c501f859c50fe728c": {
-              "stateDiff": {
-                "0xe988aa870f58bb597aadbc090e6f5508b7e93c0ad1d3effac7f5825387d9975e": "0x05626211c42f691c213286fd1cc93859d96b1e96d1e919cd2738013a25857823"
-              }
-            },
-            "0x9355d11cb5c6e8a301d131c5ee1c7fdc032dbb9a": {
-              "balance": "0x0",
-              "code": "0x363d3d373d3d3d363d735397d0869aba0d55e96d5716d383f6e1d8695ed75af43d82803e903d91602b57fd5bf3000000000000000000000000000000000000000000000000000000000000000000",
-              "nonce": "0x1",
-              "stateDiff": {
-                "0x0000000000000000000000000000000000000000000000000000000000000000": "0x000000000000000000000101679fb19dec9d66c34450a8563ffdfd29c04e615a"
-              }
-            }
-          }
-        }
-      }
-    }
-    ```
-</details>
-
-
-**<u>Sending Bottom of Block Bundles to Titan RPC</u>**
-
-Connect to the server located at:
-```
-https://fbtee.titanbuilder.xyz:1338
-```
-
-Use the `eth_sendBobBundle` method to submit bundles:
-
-```
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "eth_sendBobBundle",
-  "params": [
-    { // regular eth_sendBundle fields
-      txs,
-      blockNumber,
-    },
-    targetUuid, // String, block UUID that this bundle is targeting eg 123e4567-e89b-12d3-a456-426614174000
-    targetPools // Array[String], A list of pool addresses that this bundle is targeting
-  ]
-}
-```
-
-Note on `targetPools`:
-- Titan Builder will use `targetPools` to determine what other blocks to consider adding the bottom of block bundle to.
-- Searchers should include the address of the contract that’s state change causes the arbitrage. For example, the Uni V2 pool address.
-
 ### Searching on BuilderNet's Bottom of Block
 
-BuilderNet serves both the state diff stream and bundle submission over the same HTTPS endpoint (`rpc.buildernet.org`). Because they share one endpoint, both are reachable only in **production mode** — unlike the Flashbots and Titan bundle RPCs, which are always on.
+BuilderNet serves both the state diff stream and bundle submission over the same HTTPS endpoint (`rpc.buildernet.org`). Because they share one endpoint, both are reachable only in **production mode** — unlike the Flashbots bundle RPC, which is always on.
 
 **<u>Subscribing to BuilderNet's State Diff Stream</u>**
 


### PR DESCRIPTION
Titan Builder's bottom of block is no longer supported, so remove its endpoints
from the image config and documentation entirely.

Code (modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/):
- firewall-config: drop TITAN_* vars, the ALWAYS_OUT Titan bundle rule, and the
  PRODUCTION_OUT Titan state diff rule; update BuilderNet comments that compared
  against "Flashbots/Titan" to just "Flashbots".
- toggle-config: drop the Titan entry from PRODUCTION_ENDPOINTS.
- searcher-container-after-init: drop the fbtee.titanbuilder.xyz /etc/hosts entry.

Docs (readme.md):
- Remove the "Searching on Titan Builder's Bottom of Block" section, its TOC
  entry, the two Titan firewall-table rows, and the intro-line mention; drop the
  comparative Titan mention from the BuilderNet section.