### PR TITLE
flashbox - switch cvm-reverse-proxy to attested-tls-proxy

### DIFF
--- a/modules/flashbox/common/mkosi.build
+++ b/modules/flashbox/common/mkosi.build
@@ -42,8 +42,8 @@ make_git_package \
 
 
 # Install attested-tls-proxy
-VERSION="v2.0.0-rc.1"
-EXPECTED_SHA256=d059daa4a6a2d55a47a69ce35d81fac51fbb2571b92b131169b694cb395a163c
+VERSION="v1.1.3"
+EXPECTED_SHA256=3d3f43203bd51be399fe90ab5c633716cbecba0cb30beff291052b748610b65b
 curl -sSfL https://github.com/flashbots/attested-tls-proxy/releases/download/${VERSION}/attested-tls-proxy_1.${VERSION}_amd64.deb \
   -o $PACKAGEDIR/attested-tls-proxy.deb
 echo "${EXPECTED_SHA256}" $PACKAGEDIR/attested-tls-proxy.deb | sha256sum --check

--- a/modules/flashbox/common/mkosi.build
+++ b/modules/flashbox/common/mkosi.build
@@ -40,12 +40,13 @@ make_git_package \
     'go build -trimpath -ldflags "-s -w -buildid= -X github.com/flashbots/go-template/common.Version=v1.0.0" -o ./build/ssh-pubkey-server cmd/httpserver/main.go' \
     "build/ssh-pubkey-server:/usr/bin/ssh-pubkey-server"
 
-make_git_package \
-    "cvm-reverse-proxy" \
-    "v0.1.8" \
-    "https://github.com/flashbots/cvm-reverse-proxy" \
-    "make build-proxy-server" \
-    "build/proxy-server:/usr/bin/cvm-reverse-proxy"
+
+# Install attested-tls-proxy
+VERSION="v1.1.2"
+EXPECTED_SHA256=3b1b1868a5fcb1c0a0b07cfa32a76d2c609c99b9705596cc4a528659208d0349
+curl -sSfL https://github.com/flashbots/attested-tls-proxy/releases/download/${VERSION}/attested-tls-proxy_1.${VERSION}_amd64.deb \
+  -o $PACKAGEDIR/attested-tls-proxy.deb
+echo "${EXPECTED_SHA256}" $PACKAGEDIR/attested-tls-proxy.deb | sha256sum --check
 
 # Build input-only-proxy
 build_rust_package \

--- a/modules/flashbox/common/mkosi.build
+++ b/modules/flashbox/common/mkosi.build
@@ -42,8 +42,8 @@ make_git_package \
 
 
 # Install attested-tls-proxy
-VERSION="v1.1.2"
-EXPECTED_SHA256=3b1b1868a5fcb1c0a0b07cfa32a76d2c609c99b9705596cc4a528659208d0349
+VERSION="v2.0.0-rc.1"
+EXPECTED_SHA256=d059daa4a6a2d55a47a69ce35d81fac51fbb2571b92b131169b694cb395a163c
 curl -sSfL https://github.com/flashbots/attested-tls-proxy/releases/download/${VERSION}/attested-tls-proxy_1.${VERSION}_amd64.deb \
   -o $PACKAGEDIR/attested-tls-proxy.deb
 echo "${EXPECTED_SHA256}" $PACKAGEDIR/attested-tls-proxy.deb | sha256sum --check

--- a/modules/flashbox/common/mkosi.conf
+++ b/modules/flashbox/common/mkosi.conf
@@ -8,6 +8,8 @@ PostInstallationScripts=modules/flashbox/common/unmask-systemd.sh
                         modules/flashbox/common/mkosi.postinst
 BuildScripts=modules/flashbox/common/mkosi.build
 
+VolatilePackages=attested-tls-proxy
+
 Packages=podman
          catatonit
          runc

--- a/modules/flashbox/common/mkosi.extra/etc/systemd/system/attested-tls-proxy.service
+++ b/modules/flashbox/common/mkosi.extra/etc/systemd/system/attested-tls-proxy.service
@@ -1,14 +1,15 @@
 [Unit]
-Description=SSH Public Key Server
+Description=Attested TLS Proxy Server
 After=ssh-pubkey-server.service
 Requires=ssh-pubkey-server.service
 
 [Service]
 Type=simple
-ExecStart=cvm-reverse-proxy --listen-addr=0.0.0.0:8745 \
-            --target-addr=http://localhost:5001 \
+ExecStart=attested-tls-proxy server \
+            --inner-listen-addr=0.0.0.0:8745 \
             --server-attestation-type=auto \
-            --override-azurev6-tcbinfo
+            --allowed-remote-attestation-type none \
+            127.0.0.1:5001
 Restart=always
 RestartSec=5
 

--- a/modules/flashbox/common/mkosi.extra/etc/systemd/system/attested-tls-proxy.service
+++ b/modules/flashbox/common/mkosi.extra/etc/systemd/system/attested-tls-proxy.service
@@ -6,7 +6,7 @@ Requires=ssh-pubkey-server.service
 [Service]
 Type=simple
 ExecStart=attested-tls-proxy server \
-            --inner-listen-addr=0.0.0.0:8745 \
+            --listen-addr=0.0.0.0:8745 \
             --server-attestation-type=auto \
             --allowed-remote-attestation-type none \
             127.0.0.1:5001

--- a/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/firewall-config
+++ b/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/firewall-config
@@ -5,7 +5,7 @@
 SSH_CONTROL_PORT=22
 SSH_DATA_PORT=10022
 SSH_REGISTER_PORT=8080
-CVM_REVERSE_PROXY_PORT=8745
+ATTESTED_TLS_PROXY_PORT=8745
 SEARCHER_INPUT_UDP_PORT=27017
 SEARCHER_INPUT_TCP_PORT=27018
 
@@ -43,10 +43,10 @@ accept_dst_port $CHAIN_ALWAYS_IN tcp $SSH_CONTROL_PORT "SSH control port"
 accept_dst_port $CHAIN_ALWAYS_IN udp $SEARCHER_INPUT_UDP_PORT "Searcher UDP input channel"
 accept_dst_port $CHAIN_ALWAYS_IN tcp $SEARCHER_INPUT_TCP_PORT "Searcher TCP input channel (input-only-proxy)"
 
-# CVM reverse-proxy serves server attestation
+# attested-tls-proxy serves server attestation
 # Also forwards request to ssh pubkey server on localhost:5001,
 #    which serves searcher-container openssh server pubkey
-accept_dst_port $CHAIN_ALWAYS_IN tcp $CVM_REVERSE_PROXY_PORT "CVM reverse-proxy"
+accept_dst_port $CHAIN_ALWAYS_IN tcp $ATTESTED_TLS_PROXY_PORT "attested-tls-proxy"
 
 # Note: this is CL running on the host
 accept_dst_port $CHAIN_ALWAYS_IN tcp $CL_P2P_PORT "CL P2P (TCP)"

--- a/modules/flashbox/flashbox-l1/readme.md
+++ b/modules/flashbox/flashbox-l1/readme.md
@@ -78,7 +78,7 @@ Firewall Rules
 | 54    | Output                    | DNS                             | DNS                  | TCP + UDP | DISABLED        | ENABLED          |
 | 80    | Output                    | HTTP                            | HTTP                 | TCP       | DISABLED        | ENABLED          |
 | 443   | Output                    | HTTPS                           | HTTPS                | TCP       | DISABLED        | ENABLED          |
-| 8745  | Input                     | CVM-Reverse-Proxy               | Host                 | TCP       | ENABLED         | ENABLED          |
+| 8745  | Input                     | attested-tls-proxy              | Host                 | TCP       | ENABLED         | ENABLED          |
 | 123   | Output                    | NTP                             | Host                 | UDP       | ENABLED         | ENABLED          |
 
 **<u>Searcher Network Namespace iptables</u>**
@@ -281,22 +281,22 @@ Then, copy and paste PCR 4, 9, and 11 into the following format and save as `mea
 
 ### 3. audit and run the remote attestation software which requests the measurement from Azure’s vTPM
 
-Flashbots again leverages Edgeless Constellation’s [attested TLS](https://docs.edgeless.systems/constellation/architecture/attestation#attested-tls-atls) and other attestation primitives to interact with Azure’s attestation service. CVM-reverse-proxy fetches Azure's vTPM measurement and compares it with the locally supplied measurement.
+Flashbots again leverages Edgeless Constellation’s [attested TLS](https://docs.edgeless.systems/constellation/architecture/attestation#attested-tls-atls) and other attestation primitives to interact with Azure’s attestation service. attested-tls-proxy fetches Azure's vTPM measurement and compares it with the locally supplied measurement.
 
 ```bash
 # download remote attestation tool
 git clone https://github.com/flashbots/attested-tls-proxy.git
 cd attested-tls-proxy
-cargo run -- attested-get --allow-self-signed --measurements-file ./measurements.json --url-path pubkey  <VM IP>:8745
-TODO
 
 # This will run the client proxy that is listening on port 8080
 # and use the server reverse proxy on the deployed image as a target,
 # marshalling the measurements.json for validation of the attestation.
-./cvm-reverse-proxy/build/proxy-client \
---server-measurements ./measurements.json \
---target-addr=https://<VM IP>:8745 \
---log-debug=false
+cargo run -- client \
+  --listen-addr 127.0.0.1:8080 \
+  --allow-self-signed \
+  --measurements-file ./measurements.json \
+  --log-debug \
+  <VM IP>:8745
 
 # To trigger remote attestation, open a new terminal and run this command:
 curl http://127.0.0.1:8080
@@ -311,7 +311,7 @@ curl http://127.0.0.1:8080
 git clone https://github.com/flashbots/ssh-pubkey-server
 
 ./ssh-pubkey-server/cmd/cli/add_to_known_hosts.sh \
-./cvm-reverse-proxy/build/proxy-client \
+http://127.0.0.1:8080 \
 <MACHINE IP>
 ```
 
@@ -319,24 +319,35 @@ git clone https://github.com/flashbots/ssh-pubkey-server
 <summary>Example Output</summary>
 
     ```bash
-    # successful attestation
-    ubuntu@schmangeLina-bob-mkosi-builder:~$ ./cvm-reverse-proxy/build/proxy-client \
-    --server-measurements ./measurements.json \
-    --target-addr=https://20.57.71.148:8745 \
-    --log-debug=false
-    time=2025-07-23T14:00:33.436Z level=INFO msg="Starting proxy client" service=proxy-client version=v0.1.7-1-g4e175a4 listenAddr=127.0.0.1:8080
-    time=2025-07-23T14:00:41.224Z level=INFO msg="Validating attestation document" service=proxy-client version=v0.1.7-1-g4e175a4
-    time=2025-07-23T14:00:41.956Z level=INFO msg="Successfully validated attestation document" service=proxy-client version=v0.1.7-1-g4e175a4
-    time=2025-07-23T14:00:42.051Z level=INFO msg="[proxy-request] proxying complete" service=proxy-client version=v0.1.7-1-g4e175a4 duration=1.275184102s
+    # Start the proxy client
+    $ cargo run -- client --listen-addr 127.0.0.1:8080 --allow-self-signed --measurements-file ./measurements.json --log-debug 35.255.95.67:8745
+     Compiling attested-tls-proxy v1.1.1 (/home/pumkin/src/flashbots/attested-tls-proxy)
+      Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.17s
+       Running `target/debug/attested-tls-proxy client --listen-addr '127.0.0.1:8080' --allow-self-signed --allowed-remote-attestation-type gcp-tdx --log-debug '35.255.95.67:8745'`
+    2026-06-22T07:07:38.553942Z DEBUG attested_tls_proxy: [proxy-client] Connected to proxy server with measurements: Some(DCAP({MRTD: "feb7486608382c1ff0e15b4648ddc0acea6ca974eb53e3529f4c4bd5ffbaa20bf335cb75965cea65fe473aed9647c162", RTMR0: "e1d0235496f93f9475bf0b26d33da5c15831cfc94104d6bea7ab82db027c5f1e917d47dda6953eefae7dcb20ab6f75c4", RTMR1: "4ea5a990afef023f89e11fc32d99103d0adc91d5734664542eb980cdabc88224e1fd206d1d3b2eda71f713fdf8308a2b", RTMR2: "c42ba4fb83f99e4b90bc2a3aa9a2e81c5ac578e9a439c23b457ff7dd0d0eae958760616eff05d827289e47608e757547", RTMR3: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"}))
+      at src/lib.rs:674
 
-    # fetch the available host pubkey(s) — the dropbear key is served at boot, before `initialize`
-    ubuntu@schmangeLina-bob-mkosi-builder::~$ curl --insecure https://20.57.71.148:8745/pubkey
-    ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIYZkgqUokLPpIENJPhJAdpNTecgp/1R1RE6XMsIp6Rt
+    2026-06-22T07:07:38.554036Z DEBUG attested_tls_proxy::http_version: [client] Negotiated ALPN Some("flashbots-ratls/1+h2"), chosen protocol Http2
+      at src/http_version.rs:39
 
+    2026-06-22T07:07:44.356260Z DEBUG attested_tls_proxy: proxy-client accepted connection
+      at src/lib.rs:594
+
+    2026-06-22T07:07:44.356578Z DEBUG attested_tls_proxy: [proxy-client] Read incoming request from source client: Request { method: GET, uri: /pubkey, version: HTTP/1.1, headers: {"host": "127.0.0.1:8080", "user-agent": "curl/8.19.0", "accept": "*/*"}, body: Body(Empty) }
+      at src/lib.rs:494
+
+    2026-06-22T07:07:44.639534Z DEBUG attested_tls_proxy: [proxy-client] Read response from proxy-server: Response { status: 200, version: HTTP/2.0, headers: {"date": "Mon, 22 Jun 2026 07:07:44 GMT", "content-length": "80", "content-type": "text/plain; charset=utf-8"}, body: Body(Streaming) }
+    at src/lib.rs:498
+
+    $ curl http://127.0.0.1:8080/pubkey | less
+    % Total    % Received % Xferd  Average Speed  Time    Time    Time   Current
+    Dload  Upload  Total   Spent   Left   Speed
+    100     80 100     80   0      0    280      0                              0
+    ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHqPgQoc6yLlMsRUvEeV+6oUsvCMV1sr+b1uKTLzu4e9
     ```
   </details>
 
-If cvm-reverse-proxy returns `Successfully validated attestation document`, the searcher has now verified that they SSH into a genuine TDX VM, running the exact same image as the one they audited locally. In doing so, the searcher has also verified that no one else has access to the container or host, and they can safely upload your arbitrage bot inside ✨🚀
+If attested-tls-proxy client is able to successfully make a connection to the proxy server, the searcher has now verified that they SSH into a genuine TDX VM, running the exact same image as the one they audited locally. In doing so, the searcher has also verified that no one else has access to the container or host, and they can safely upload your arbitrage bot inside ✨🚀
 
 Order Flow APIs
 ------------------------
@@ -613,7 +624,7 @@ Developer Notes
 7. Lighthouse (**name:** `lighthouse.service`) (**after:** `/persistent` is mounted)
 8. Start the podman container (**name:** `searcher-container.service`) (**after:** `dropbear.service`, `lighthouse.service`, `searcher-firewall.service`, `/persistent` is mounted)
 9. SSH pubkey server (**name:** `ssh-pubkey-server.service`) (**after:** `dropbear.service`) — starts at boot and no longer waits for `searcher-container.service`, so `/pubkey` serves the host (dropbear) key before disk init. The container key is served by `/pubkey` lazily once the container writes it.
-10. CVM reverse proxy for SSH pubkey server (**name:** `cvm-reverse-proxy.service`) (**after:** `ssh-pubkey-server.service`) — consequently the attested `:8745` channel is also available at boot, before the searcher's first SSH.
+10. Attested TLS proxy for SSH pubkey server (**name:** `attested-tls-proxy.service`) (**after:** `ssh-pubkey-server.service`) — consequently the attested `:8745` channel is also available at boot, before the searcher's first SSH.
 
 ### Testing
 

--- a/modules/flashbox/flashbox-l1/readme.md
+++ b/modules/flashbox/flashbox-l1/readme.md
@@ -285,9 +285,10 @@ Flashbots again leverages Edgeless Constellation’s [attested TLS](https://docs
 
 ```bash
 # download remote attestation tool
-git clone https://github.com/flashbots/cvm-reverse-proxy.git
-cd cvm-reverse-proxy
-make build-proxy-client
+git clone https://github.com/flashbots/attested-tls-proxy.git
+cd attested-tls-proxy
+cargo run -- attested-get --allow-self-signed --measurements-file ./measurements.json --url-path pubkey  <VM IP>:8745
+TODO
 
 # This will run the client proxy that is listening on port 8080
 # and use the server reverse proxy on the deployed image as a target,

--- a/modules/flashbox/flashbox-l1/readme.md
+++ b/modules/flashbox/flashbox-l1/readme.md
@@ -323,7 +323,7 @@ http://127.0.0.1:8080 \
     $ cargo run -- client --listen-addr 127.0.0.1:8080 --allow-self-signed --measurements-file ./measurements.json --log-debug 35.255.95.67:8745
      Compiling attested-tls-proxy v1.1.1 (/home/pumkin/src/flashbots/attested-tls-proxy)
       Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.17s
-       Running `target/debug/attested-tls-proxy client --listen-addr '127.0.0.1:8080' --allow-self-signed --allowed-remote-attestation-type gcp-tdx --log-debug '35.255.95.67:8745'`
+       Running `target/debug/attested-tls-proxy client --listen-addr '127.0.0.1:8080' --allow-self-signed --measurements-file ./measurements.json --log-debug '35.255.95.67:8745'`
     2026-06-22T07:07:38.553942Z DEBUG attested_tls_proxy: [proxy-client] Connected to proxy server with measurements: Some(DCAP({MRTD: "feb7486608382c1ff0e15b4648ddc0acea6ca974eb53e3529f4c4bd5ffbaa20bf335cb75965cea65fe473aed9647c162", RTMR0: "e1d0235496f93f9475bf0b26d33da5c15831cfc94104d6bea7ab82db027c5f1e917d47dda6953eefae7dcb20ab6f75c4", RTMR1: "4ea5a990afef023f89e11fc32d99103d0adc91d5734664542eb980cdabc88224e1fd206d1d3b2eda71f713fdf8308a2b", RTMR2: "c42ba4fb83f99e4b90bc2a3aa9a2e81c5ac578e9a439c23b457ff7dd0d0eae958760616eff05d827289e47608e757547", RTMR3: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"}))
       at src/lib.rs:674
 

--- a/modules/flashbox/flashbox-l2/mkosi.extra/etc/bob/firewall-config
+++ b/modules/flashbox/flashbox-l2/mkosi.extra/etc/bob/firewall-config
@@ -5,7 +5,7 @@
 SSH_CONTROL_PORT=22
 SSH_DATA_PORT=10022
 SSH_REGISTER_PORT=8080
-CVM_REVERSE_PROXY_PORT=8745
+ATTESTED_TLS_PROXY_PORT=8745
 SEARCHER_INPUT_UDP_PORT=27017
 SEARCHER_INPUT_TCP_PORT=27018
 
@@ -36,10 +36,10 @@ accept_dst_port $CHAIN_ALWAYS_IN tcp $SEARCHER_INPUT_TCP_PORT "Searcher TCP inpu
 # We assume here that static peers in config are only syn nodes
 accept_src_ip_dst_port $CHAIN_ALWAYS_IN tcp "$CONFIG_EL_PEERS_IPS" $ENGINE_API_PORT "Engine API"
 
-# CVM reverse-proxy serves server attestation
+# attested-tls-proxy serves server attestation
 # Also forwards request to ssh pubkey server on localhost:5001,
 #    which serves searcher-container openssh server pubkey
-accept_dst_port $CHAIN_ALWAYS_IN tcp $CVM_REVERSE_PROXY_PORT "CVM reverse-proxy"
+accept_dst_port $CHAIN_ALWAYS_IN tcp $ATTESTED_TLS_PROXY_PORT "attested-tls-proxy"
 
 ###########################################################################
 # (2) ALWAYS_OUT: Outbound rules that are always applied

--- a/modules/flashbox/observability/mkosi.postinst
+++ b/modules/flashbox/observability/mkosi.postinst
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 # Ensure prometheus owns its data directory

--- a/scripts/gcp_measurements_to_dcap.sh
+++ b/scripts/gcp_measurements_to_dcap.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # TEMPORARY: reshape dstack-mr GCP measurements (make measure-gcp ->
-# build/gcp_measurements.json) into cvm-reverse-proxy's dcap-tdx
-# --server-measurements format. Drop once cvm-reverse-proxy accepts the
+# build/gcp_measurements.json) into attestd-tls-proxy's dcap-tdx
+# --measurements-file format. Drop once attested-tls-proxy accepts the
 # condensed dstack-mr output directly.
 #
 # dstack-mr emits mrtd[] (one per known GCP firmware) and rtmr0[] (equal-size
 # per-firmware chunks: firmware x machine-type-ACPI x boot variants), while
-# cvm-reverse-proxy wants flat measurement sets it ORs over. We pair mrtd[i]
+# attested-tls-proxy wants flat measurement sets it ORs over. We pair mrtd[i]
 # with its rtmr0 chunk; a genuine quote matches exactly one set.
 #
 # Usage: scripts/gcp_measurements_to_dcap.sh [gcp_measurements.json] > out.json

--- a/scripts/gcp_measurements_to_dcap.sh
+++ b/scripts/gcp_measurements_to_dcap.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # TEMPORARY: reshape dstack-mr GCP measurements (make measure-gcp ->
-# build/gcp_measurements.json) into attestd-tls-proxy's dcap-tdx
+# build/gcp_measurements.json) into attested-tls-proxy's dcap-tdx
 # --measurements-file format. Drop once attested-tls-proxy accepts the
 # condensed dstack-mr output directly.
 #

--- a/scripts/make_git_package.sh
+++ b/scripts/make_git_package.sh
@@ -43,7 +43,7 @@ make_git_package() {
                 mkdir -p "$DESTDIR$dest"
                 cp -r "$cache_dir/$src"/* "$DESTDIR$dest/"
             else
-                cp "$cache_dir/$src" "$DESTDIR$dest"
+                install -m 755 "$cache_dir/$src" "$DESTDIR$dest"
             fi
         done
         return 0
@@ -66,7 +66,7 @@ make_git_package() {
             cp -r "$build_dir/$src"/* "$DESTDIR$dest/"
         else
             mkdir -p "$(dirname "$DESTDIR$dest")"
-            cp "$build_dir/$src" "$DESTDIR$dest"
+            install -m 755 "$build_dir/$src" "$DESTDIR$dest"
         fi
 
         # Cache artifact

--- a/shared/mkosi.conf
+++ b/shared/mkosi.conf
@@ -19,7 +19,7 @@ Seed=630b5f72-a36a-4e83-b23d-6ef47c82fd9c
 
 [Content]
 SourceDateEpoch=0
-KernelCommandLine=console=tty0 console=ttyS0,115200n8 mitigations=auto,nosmt spec_store_bypass_disable=on nospectre_v2 transparent_hugepage=madvise systemd.unit=minimal.target
+KernelCommandLine=console=tty0 console=ttyS0,115200n8 mitigations=auto,nosmt spec_store_bypass_disable=on nospectre_v2 transparent_hugepage=madvise systemd.unit=minimal.target systemd.journald.forward_to_console=yes
 ExtraTrees=shared/mkosi.extra
 BuildScripts=shared/mkosi.build.d/*
 SyncScripts=shared/mkosi.sync.d/*

--- a/shared/mkosi.conf
+++ b/shared/mkosi.conf
@@ -19,7 +19,7 @@ Seed=630b5f72-a36a-4e83-b23d-6ef47c82fd9c
 
 [Content]
 SourceDateEpoch=0
-KernelCommandLine=console=tty0 console=ttyS0,115200n8 mitigations=auto,nosmt spec_store_bypass_disable=on nospectre_v2 transparent_hugepage=madvise systemd.unit=minimal.target systemd.journald.forward_to_console=yes
+KernelCommandLine=console=tty0 console=ttyS0,115200n8 mitigations=auto,nosmt spec_store_bypass_disable=on nospectre_v2 transparent_hugepage=madvise systemd.unit=minimal.target
 ExtraTrees=shared/mkosi.extra
 BuildScripts=shared/mkosi.build.d/*
 SyncScripts=shared/mkosi.sync.d/*


### PR DESCRIPTION
This switches `cvm-reverse-proxy` to `attested-tls-proxy`.

The purpose is to avoid a licensing issue and use more actively maintained attestation generation and verification code.

I have tried to make this as unopinionated as possible, making a drop-in replacement giving the exact same functionality as before.

This does **NOT** use the new nested attested TLS protocol.  It is the older protocol which is currently used on Buildernet.  The only difference between the 1.1.3 release used here and 1.1.2 currently used by Buildernet is some dependency updates relating to attestation.

I have tested the documented workflow for retrieving ssh public key on a GCP deployment.

Note that support for dstack-mr style measurement is still not merged - neither in attested-tls used here: https://github.com/flashbots/attested-tls/pull/56 or in cvm-reverse-proxy: https://github.com/flashbots/cvm-reverse-proxy/pull/49