### PR TITLE
Bnet: Bump rbuilder-operator + rebalancer to v1.7.2

### DIFF
--- a/mkosi.images/buildernet/mkosi.extra/etc/systemd/system/rbuilder-operator-rebalancer-downloader.service
+++ b/mkosi.images/buildernet/mkosi.extra/etc/systemd/system/rbuilder-operator-rebalancer-downloader.service
@@ -5,14 +5,14 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-Environment=RBUILDER_OPERATOR_SHA256SUM=02d2bee0ba22f76b1ea13cb178413d18d1b8dd6cdd331e03835f4761df2e2fb1 \
-            RBUILDER_OPERATOR_TAG=v1.6.8 \
+Environment=RBUILDER_OPERATOR_SHA256SUM=416abc1fc14121ca14b8992359cf6edee33a1cf5cd61ffccbadadaa5f2009c4e \
+            RBUILDER_OPERATOR_TAG=v1.7.2 \
             RBUILDER_OPERATOR_REPO=rbuilder-prism \
-            RBUILDER_OPERATOR_ARTIFACT=rbuilder-operator-v1.6.8-x86_64-unknown-linux-gnu \
+            RBUILDER_OPERATOR_ARTIFACT=rbuilder-operator-v1.7.2-x86_64-unknown-linux-gnu \
             RBUILDER_REBALANCER_SHA256SUM=8ea7a0e579e23ec4f35efd9d80d851768594606b4fdc936432f01745fc2a6a5c \
-            RBUILDER_REBALANCER_TAG=v1.6.8 \
+            RBUILDER_REBALANCER_TAG=v1.7.2 \
             RBUILDER_REBALANCER_REPO=rbuilder-prism \
-            RBUILDER_REBALANCER_ARTIFACT=rbuilder-rebalancer-v1.6.8-x86_64-unknown-linux-gnu
+            RBUILDER_REBALANCER_ARTIFACT=rbuilder-rebalancer-v1.7.2-x86_64-unknown-linux-gnu
 EnvironmentFile=%E/gh_token.env
 
 # rbuilder-operator

--- a/mkosi.images/buildernet/mkosi.extra/usr/lib/mustache-templates/etc/rbuilder-operator/config.toml.mustache_unsafe_400
+++ b/mkosi.images/buildernet/mkosi.extra/usr/lib/mustache-templates/etc/rbuilder-operator/config.toml.mustache_unsafe_400
@@ -32,6 +32,7 @@ optimistic_v3_relay_pubkeys = {{{rbuilder.optimistic_v3_relay_pubkeys}}}
 priority_update_grpc_server_ip = "127.0.0.1"
 priority_update_grpc_server_port = 8745
 priority_update_simulation_threads = 1
+priority_update_takers_speed_bump_ms = 50
 relay_secret_key = "{{rbuilder.relay_secret_key}}"
 require_non_empty_blocklist = {{rbuilder.require_non_empty_blocklist}}
 reth_db_path = "/var/lib/persistent/reth/db"


### PR DESCRIPTION
See title. Also pairs with config addition of `priority_update_takers_speed_bump_ms`.