### PR TITLE
Add support for kernel modules

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -130,7 +130,7 @@ jobs:
 
       - name: Generate SHA256 checksums
         run: |
-          sha256sum build/${{ matrix.image }}_*.efi | tee build/checksum.sha256
+          sha256sum $(ls build/${{ matrix.image }}_*.efi build/${{ matrix.image }}_*.raw build/${{ matrix.image }}_*.tar.gz 2>/dev/null) | tee build/checksum.sha256
 
       - name: Upload checksum for reprotest
         if: inputs.reprotest == true
@@ -175,7 +175,7 @@ jobs:
 
       - name: Generate SHA256 checksum
         run: |
-          sha256sum build/${{ matrix.image }}_*.efi | tee build/checksum.sha256
+          sha256sum $(ls build/${{ matrix.image }}_*.efi build/${{ matrix.image }}_*.raw build/${{ matrix.image }}_*.tar.gz 2>/dev/null) | tee build/checksum.sha256
 
       - name: Upload checksum
         uses: actions/upload-artifact@v4
@@ -203,22 +203,12 @@ jobs:
       - name: Compare SHA256 hashes
         run: |
           echo "=== Reproducibility Check for ${{ matrix.image }} ==="
-          echo "Build 1 (all artifacts):"
-          cat checksums/checksum-${{ matrix.image }}-build-1/*.sha256
-          echo "Build 2 (EFI only):"
-          cat checksums/checksum-${{ matrix.image }}-build-2/checksum.sha256
-
-          # Extract only the .efi hash from build-1 to compare with build-2
-          hash1=$(grep '\.efi$' checksums/checksum-${{ matrix.image }}-build-1/*.sha256 | awk '{print $1}')
-          hash2=$(awk '{print $1}' checksums/checksum-${{ matrix.image }}-build-2/checksum.sha256)
-
-          echo ""
-          echo "EFI hash build-1: $hash1"
-          echo "EFI hash build-2: $hash2"
-
-          if [ "$hash1" = "$hash2" ]; then
-            echo "✅ SUCCESS: ${{ matrix.image }} images are identical (reproducible build verified)"
+          b1=checksums/checksum-${{ matrix.image }}-build-1/checksum.sha256
+          b2=checksums/checksum-${{ matrix.image }}-build-2/checksum.sha256
+          cat "$b1" "$b2"
+          if diff <(sort "$b1") <(sort "$b2"); then
+            echo "✅ SUCCESS: ${{ matrix.image }} artifacts are identical (reproducible build verified)"
           else
-            echo "❌ FAILURE: ${{ matrix.image }} images differ (reproducible build failed)"
+            echo "❌ FAILURE: ${{ matrix.image }} artifacts differ (reproducible build failed)"
             exit 1
           fi

--- a/shared/mkosi.build.d/10-kernel.sh
+++ b/shared/mkosi.build.d/10-kernel.sh
@@ -23,6 +23,11 @@ for dir_var in "${!KERNEL_CONFIG_SNIPPETS@}"; do
     config_paths+=("$SRCDIR/${!dir_var}"/*)
 done
 
+# If KERNEL_MODULES is set, include the config fragments for enabling module support
+if [[ -n "${KERNEL_MODULES:-}" ]]; then
+    config_paths+=("$SRCDIR/shared/kernel/modules.config")
+fi
+
 # Auto-discover patches from registered directories
 # KERNEL_PATCHES is processed first, then KERNEL_PATCHES_* in alphabetical order
 patch_paths=()
@@ -50,6 +55,7 @@ cache_hash=$(
 )
 cache_dir="$BUILDDIR/kernel-${KERNEL_VERSION}-${cache_hash}"
 cached_deb="$cache_dir/kernel.deb"
+cached_headers_deb="$cache_dir/headers.deb"
 
 cat <<EOF > "$BUILDDIR/manifest.md"
 | component  | version  | built / cached  | size  | duration  |
@@ -131,10 +137,19 @@ else
     export KBUILD_BUILD_USER="mkosi"
     export KBUILD_BUILD_HOST="mkosi-builder"
     export LOCALVERSION  # suffix appended to kernel version, e.g. -mkosi-cloud
-    export DEB_BUILD_PROFILES='pkg.linux-upstream.nokernelheaders pkg.linux-upstream.nokerneldbg'
+    
+    if [[ -z "${KERNEL_MODULES:-}" ]]; then
+        export DEB_BUILD_PROFILES='pkg.linux-upstream.nokerneldbg pkg.linux-upstream.nokernelheaders'
+    else
+        export DEB_BUILD_PROFILES='pkg.linux-upstream.nokerneldbg'
+    fi
+
     rm -f "${kernel_src_dir}/.version"
 
     mkosi-chroot --chdir "${chroot_kernel_src_dir}" make olddefconfig
+    if [[ -n "${KERNEL_MODULES:-}" ]]; then
+        mkosi-chroot --chdir "${chroot_kernel_src_dir}" make mod2yesconfig
+    fi
     mkosi-chroot --chdir "${chroot_kernel_src_dir}" make -j "$(nproc 2>/dev/null || echo 2)" bindeb-pkg
 
     built_deb=$(find "${kernel_build_dir}" -maxdepth 1 -name "linux-image-*${LOCALVERSION}_*.deb" -type f | head -1)
@@ -150,9 +165,13 @@ else
     seconds=$(( $( date +%s ) - ts ))
     duration=$( printf "%dm%ds" $(( seconds / 60 )) $(( seconds % 60 )) )
 
-    # Cache the .deb
+    # Cache .deb files
     mkdir -p "${cache_dir}"
     cp "${built_deb}" "${cached_deb}"
+    if [[ -n "${KERNEL_MODULES:-}" ]]; then
+        built_headers_deb=$(find "${kernel_build_dir}" -maxdepth 1 -name "linux-headers-*${LOCALVERSION}_*.deb" -type f | head -1)
+        cp "${built_headers_deb}" "${cached_headers_deb}"
+    fi
     cp "${kernel_src_dir}/.config" "${cache_dir}/config"
     echo "${kernel_version_string}" > "${cache_dir}/kernel.release"
     echo "Cached kernel to: ${cache_dir}"
@@ -160,6 +179,11 @@ else
     rm -rf "${kernel_build_dir}"
 
     echo "| \`kernel\`  | \`${KERNEL_VERSION}\` (config hash \`${cache_hash}\`)  | built  | \`$( du -sh "$cached_deb" | cut -f1 )\`  | \`$duration\`  |" >> "$BUILDDIR/manifest.md"
+fi
+
+if [[ -n "${KERNEL_MODULES:-}" ]]; then
+    mkosi-chroot dpkg -i "${CHROOT_BUILDDIR}/kernel-${KERNEL_VERSION}-${cache_hash}/headers.deb"
+    echo "Kernel headers installed into the build environment"
 fi
 
 # Copy to PACKAGEDIR for mkosi VolatilePackages installation

--- a/shared/mkosi.finalize.d/90-debloat.sh
+++ b/shared/mkosi.finalize.d/90-debloat.sh
@@ -57,6 +57,9 @@ skip_paths=()
 for var in "${!SKIP_DEBLOAT_PATHS@}"; do
     skip_paths+=(${!var})
 done
+if [[ -n "${KERNEL_MODULES:-}" ]]; then
+    skip_paths+=("/usr/lib/modules")
+fi
 skip=" ${skip_paths[*]} "
 
 for p in "${debloat_paths[@]}"; do


### PR DESCRIPTION
Adds support for compiling out of tree kernel modules into mkosi packages.

To use, add the following to kernel config:

```
[Build]
Environment=KERNEL_MODULES=1
```

This will enable kernel module support and automatically make the kernel headers available during mkosi.build.

@h4x3rotab