### PR TITLE
Fix reproducibility issue with recent rosetta versions

### DIFF
--- a/shared/mkosi.finalize.d/90-debloat.sh
+++ b/shared/mkosi.finalize.d/90-debloat.sh
@@ -44,6 +44,7 @@ debloat_paths=(
     "/var/lib/ucf"
     "/etc/credstore"
     "/nix"
+    "/.cache"
 )
 
 if [[ ! "${PROFILES:-}" == *"devtools"* ]]; then


### PR DESCRIPTION
There was a Apple Silicon reproducibility regression due to recent rosetta versions leaving files in `/.cache`, which this PR fixes by adding that directory to the debloat list.