### PR TITLE
Add Mac dev tooling

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,49 @@
+# Development
+
+## Building
+
+On Linux, install mkosi as per the README and use `mkosi -I buildernet.conf` directly,
+or use the make targets below with a `.bypass-lima` file in the repo root.
+
+On macOS (or any host without native mkosi support), the make targets run every command
+inside a per-repo [Lima](https://lima-vm.io) VM (`brew install lima`). The VM is created
+automatically on first use from `lima.yaml`, with the repo mounted at `~/mnt` and mkosi
+installed into a venv pinned to `.mkosi_version`.
+
+```bash
+make help          # list targets
+make smoke         # tiny test image. validates the toolchain
+make build         # full BuilderNet images (azure, gcp, qemu)
+make build-dev     # + devtools profile (apt, tcpdump, strace, vim, ...)
+make build-local   # + local profile too (root autologin), for `make boot`
+make boot          # boot the built qemu UKI (kernel log on stdio; Ctrl-A X to exit)
+make console       # second terminal: root shell via hvc0 (local profile autologin)
+make clean         # remove build artifacts (keeps the VM)
+make stop-vm       # stop this repo's Lima VM (keeps its disk; restarts on next make)
+make clean-vm      # delete the Lima VM entirely
+```
+
+Resource overrides at VM creation time: `LIMA_CPUS=12 LIMA_MEMORY=32GiB make build`.
+To resize an existing VM, edit `~/.lima/tee-builder-*/lima.yaml` and restart it.
+
+### How the Lima build works
+
+`scripts/env_wrapper.sh`:
+1. Creates/starts a VM named `tee-builder-<sha256(repo path)[:8]>` (one VM per checkout).
+2. Ensures a venv with mkosi pinned to `.mkosi_version` exists inside the VM.
+3. rsyncs the working tree to a VM-local directory (`~/.cache/tee-builder/src`) and runs
+   the command there. mkosi cannot build directly on the virtiofs mount: it is slow and
+   mkosi's cross-device rename fallback breaks on hardlink-rich trees (e.g. the default
+   tools tree). Cache/build dirs persist VM-side between builds.
+4. Copies resulting artifact files back to `mkosi.output/` in the repo.
+
+Apple Silicon note: images are x86-64 (`--architecture=x86-64` is set by the Makefile but
+the kernel config is amd64-only). Build scripts run under Rosetta; booting with
+`make boot` uses TCG emulation, so guest boot takes a few minutes.
+
+### Gotchas
+
+- First build downloads a ~1.6G mkosi tools tree and compiles the kernel; expect ~20 min
+  on native Linux, noticeably longer under Rosetta.
+- For iteration speed when you don't need reth/lighthouse, put `exit 0` at the top of
+  `mkosi.images/buildernet/mkosi.build.d/{10-reth,18-lighthouse}.sh.chroot` (do not commit).

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,77 @@
+.DEFAULT_GOAL := help
+
+SHELL := /usr/bin/env bash
+WRAPPER := scripts/env_wrapper.sh
+
+# Lima build VM name, mirroring scripts/env_wrapper.sh: tee-builder-<sha256(repo path)[:8]>.
+ifndef LIMA_VM
+LIMA_VM := tee-builder-$(shell printf '%s' "$(CURDIR)" | { command -v sha256sum >/dev/null 2>&1 && sha256sum || shasum -a 256; } | cut -c1-8)
+endif
+
+# our kernel config is amd64-only, but on Apple Silicon the Lima VM is arm64
+# and mkosi defaults to the host arch
+ARCH := --architecture=x86-64
+
+##@ Help
+
+# Awk script from https://github.com/paradigmxyz/reth/blob/main/Makefile
+.PHONY: help
+help: ## display their help.
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Build
+
+.PHONY: build build-dev build-local smoke boot clean clean-vm stop-vm
+
+build: ## build all BuilderNet images (azure, gcp, qemu)
+	$(WRAPPER) mkosi $(ARCH) --force -I buildernet.conf build
+
+build-dev: ## build with devtools profile (apt, tcpdump, strace, ...)
+	$(WRAPPER) mkosi $(ARCH) --force --profile=devtools -I buildernet.conf build
+
+build-local: ## build with local+devtools profiles (root autologin console, for `make boot`)
+	$(WRAPPER) mkosi $(ARCH) --force --profile=local --profile=devtools -I buildernet.conf build
+
+smoke: ## tiny quick image build to validate the toolchain 
+	$(WRAPPER) mkosi -C tests/smoke --force build
+	@echo "Smoke build OK"
+
+##@ Run
+
+boot: ## boot the built qemu UKI (no disk/TPM). root shell: `make console` in another terminal
+	$(WRAPPER) bash -c 'qemu-system-x86_64 -m 6G -smp 4 -nographic -cpu max \
+	  -drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE_4M.fd \
+	  -kernel $$(ls -t mkosi.output/buildernet-qemu_*.efi | head -1) \
+	  -nic user,model=virtio-net-pci \
+	  -chardev socket,id=hvc0,path=/tmp/hvc0.sock,server=on,wait=off \
+	  -device virtio-serial-pci \
+	  -device virtconsole,chardev=hvc0'
+
+console: ## attach to the root shell of a VM started with `make boot` (detach: Enter ~ .)
+	$(WRAPPER) socat -,raw,echo=0 UNIX-CONNECT:/tmp/hvc0.sock
+
+##@ Utils
+
+clean: ## remove build artifacts, host-side and in the Lima build VM (keeps the VM)
+	rm -rf mkosi.output/* mkosi.builddir/* mkosi.cache/* tests/smoke/mkosi.output tests/smoke/mkosi.tools
+	@if command -v limactl >/dev/null 2>&1 && limactl list 2>/dev/null | grep -q "^$(LIMA_VM)"; then \
+		echo "Cleaning build artifacts inside Lima VM '$(LIMA_VM)'..."; \
+		$(WRAPPER) rm -rf mkosi.output mkosi.builddir mkosi.cache tests/smoke/mkosi.output tests/smoke/mkosi.tools; \
+	fi
+
+stop-vm: ## stop this repo's Lima build VM (override with LIMA_VM=; keeps its disk)
+	@if ! command -v limactl >/dev/null 2>&1; then echo "limactl not found."; exit 0; fi; \
+	if [ "$$(limactl list "$(LIMA_VM)" --format '{{.Status}}' 2>/dev/null)" = "Running" ]; then \
+		echo "Stopping '$(LIMA_VM)'..."; limactl stop "$(LIMA_VM)"; \
+	else \
+		echo "No running Lima VM '$(LIMA_VM)'."; \
+	fi
+
+clean-vm: ## stop and delete this repo's Lima build VM (override with LIMA_VM=; destroys its contents)
+	@if command -v limactl >/dev/null 2>&1 && limactl list 2>/dev/null | grep -q "^$(LIMA_VM)"; then \
+		echo "Stopping and deleting Lima VM '$(LIMA_VM)'..."; \
+		limactl stop "$(LIMA_VM)" || true; \
+		limactl delete "$(LIMA_VM)" || true; \
+	else \
+		echo "No Lima VM '$(LIMA_VM)' found."; \
+	fi

--- a/lima.yaml
+++ b/lima.yaml
@@ -1,0 +1,36 @@
+# Pinned to the dated release (matches the digest of existing tee-builder VMs)
+images:
+  - location: https://cloud.debian.org/images/cloud/bookworm/20260413-2447/debian-12-genericcloud-amd64-20260413-2447.qcow2
+    arch: x86_64
+    digest: sha512:db11b13c4efcc37828ffadae521d101e85079d349e1418074087bb7d306f11caccdc2b0b539d6fd50d623d40a898f83c6137268a048d7700397dc35b7dcbc927
+  - location: https://cloud.debian.org/images/cloud/bookworm/20260413-2447/debian-12-genericcloud-arm64-20260413-2447.qcow2
+    arch: aarch64
+    digest: sha512:15ad6c52e255c84eb0e91001c5907b27199d8a7164d8ac172cfe9c92850dfaf606a6c3161d6af7f0fd5a5fef2aa8dcd9a23c2eb0fedbfcddb38e2bc306cba98f
+cpus: 8
+memory: 16GiB
+disk: 100GiB
+user:
+  name: debian
+  uid: 1000
+  home: /home/debian
+vmOpts:
+  vz:
+    rosetta:
+      enabled: true
+      binfmt: true
+containerd:
+  # prevent lima installing 100s MB of containerd stuff
+  user: false
+mountTypesUnsupported: [9p]
+ssh:
+  forwardAgent: true
+provision:
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -euo pipefail
+      apt-get update
+      apt-get install -y curl git rsync sudo debian-archive-keyring apt-utils dpkg-dev \
+        build-essential uidmap python3-pip python3-venv \
+        qemu-system-x86 ovmf swtpm socat
+      echo "debian ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/debian

--- a/mkosi.sandbox/etc/apt/apt.conf.d/80-retries
+++ b/mkosi.sandbox/etc/apt/apt.conf.d/80-retries
@@ -1,0 +1,4 @@
+# snapshot.debian.org rate-limits (TooManyRequests 503);
+# make apt retry each fetch with backoff instead of failing the build
+Acquire::Retries "20";
+Acquire::Retries::Delay::Maximum "60";

--- a/scripts/env_wrapper.sh
+++ b/scripts/env_wrapper.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# script that runs on `make build`.
+#
+# on macOS (or other non-linux hosts) the command is shipped into a per-repo
+# Lima VM. the VM is created on first use from lima.yaml, the repo is mounted
+# at ~/mnt inside it, and mkosi is installed there pinned to .mkosi_version.
+# build artifacts are copied back to mkosi.output/ in the repo when done.
+#
+# if already on Linux, you can create a `.bypass-lima` file in the repo root and this
+# script gets out of the way (install mkosi per the README).
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# use sha256sum or shasum (linux=>sha256sum, macOS=>shasum)
+sha256() {
+    if command -v sha256sum &>/dev/null; then sha256sum; else shasum -a 256; fi
+}
+
+# VM is named after a hash of the repo path (tee-builder-<hash>)
+REPO_HASH="$(echo -n "$REPO_DIR" | sha256 | cut -c1-8)"
+LIMA_VM="${LIMA_VM:-tee-builder-$REPO_HASH}"
+
+should_use_lima() {
+    [ ! -f "$REPO_DIR/.bypass-lima" ]
+}
+
+setup_lima() {
+    if ! command -v limactl &>/dev/null; then
+        echo "Lima is not installed. Please install Lima to use this script."
+        echo "Visit: https://lima-vm.io/docs/installation/"
+        exit 1
+    fi
+
+    if ! limactl list "$LIMA_VM" > /dev/null 2>&1; then
+        declare -a args=()
+        [ -n "${LIMA_CPUS:-}" ] && args+=("--cpus" "$LIMA_CPUS")
+        [ -n "${LIMA_MEMORY:-}" ] && args+=("--memory" "$LIMA_MEMORY")
+        [ -n "${LIMA_DISK:-}" ] && args+=("--disk" "$LIMA_DISK")
+
+        echo "Creating Lima VM '$LIMA_VM' for $REPO_DIR..."
+        limactl create -y \
+            --set '.mounts = [{"location": "'"$REPO_DIR"'", "mountPoint": "/home/debian/mnt", "writable": true}]' \
+            --name "$LIMA_VM" ${args[@]+"${args[@]}"} "$REPO_DIR/lima.yaml"
+    fi
+
+    status=$(limactl list "$LIMA_VM" --format "{{.Status}}")
+    if [ "$status" != "Running" ]; then
+        echo "Starting Lima VM '$LIMA_VM'..."
+        limactl start -y "$LIMA_VM"
+    fi
+}
+
+# make cmds travel into the VM over Lima's generated ssh config
+lima_exec() {
+    # -t: give interactive commands a TTY (qemu console, mkosi progress bars)
+    # LogLevel=QUIET: hide SSH's "Shared connection closed" noise
+    ssh -F "$HOME/.lima/$LIMA_VM/ssh.config" "lima-$LIMA_VM" \
+        -t -o LogLevel=QUIET \
+        -- "$@"
+}
+
+# exit here if being sourced
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] && return 0
+
+if [ $# -eq 0 ]; then
+    echo "Error: No command specified"
+    exit 1
+fi
+
+# quote cmds
+cmd_q="$(printf '%q ' "$@")"
+
+# What actually runs inside the VM, every time:
+#
+#  1. Make sure the right mkosi exists: a venv keyed by the git sha in
+#     .mkosi_version. bump the pin and the new version installs itself.
+#  2. rsync the repo to real Linux disk first. mkosi cannot build directly on
+#     the macOS<->VM shared mount (virtiofs). caches/outputs are excluded from
+#     sync so they persist in the VM between runs.
+#  3. run cmd from the synced copy. umask 022 for reproducibility
+#  4. ship build artifacts back to the repo's mkosi.output/ on host.
+remote_script="
+set -euo pipefail
+MKOSI_REF=\$(cat ~/mnt/.mkosi_version)
+VENV=~/.cache/mkosi-venvs/\$MKOSI_REF
+if [ ! -x \$VENV/bin/mkosi ]; then
+    echo \"Installing mkosi @\$MKOSI_REF into \$VENV...\"
+    command -v git >/dev/null || sudo apt-get install -y -qq git
+    python3 -m venv \$VENV
+    \$VENV/bin/pip install --quiet --upgrade pip
+    \$VENV/bin/pip install --quiet \"git+https://github.com/systemd/mkosi.git@\$MKOSI_REF\"
+fi
+command -v rsync >/dev/null || sudo apt-get install -y -qq rsync
+
+SRC=~/.cache/tee-builder/src
+mkdir -p \$SRC
+rsync -a --delete \
+    --exclude .git \
+    --exclude .DS_Store \
+    --exclude 'mkosi.output/' \
+    --exclude 'mkosi.builddir/' \
+    --exclude 'mkosi.cache/' \
+    --exclude 'mkosi.tools*' \
+    ~/mnt/ \$SRC/
+mkdir -p \$SRC/mkosi.output \$SRC/mkosi.builddir \$SRC/mkosi.cache
+
+cd \$SRC
+umask 022
+export PATH=\$VENV/bin:\$PATH
+set -- $cmd_q
+\"\$@\"
+
+mkdir -p ~/mnt/mkosi.output
+# copy build artifacts back to the host. skips unnecessary dirs
+for d in \$SRC/mkosi.output \$SRC/tests/*/mkosi.output; do
+    [ -d \"\$d\" ] || continue
+    find \"\$d\" -maxdepth 1 -type f -exec cp -f -t ~/mnt/mkosi.output/ {} +
+done
+"
+
+if should_use_lima; then
+    setup_lima
+
+    # mounted repo is owned by host user, not the VM user; tells git
+    # inside the VM it is safe to touch.
+    lima_exec "git config --global --get-all safe.directory 2>/dev/null | grep -Fxq ~/mnt || git config --global --add safe.directory ~/mnt"
+
+    lima_exec "$remote_script"
+
+    echo "Note: Lima VM '$LIMA_VM' is still running. To stop it, run: limactl stop $LIMA_VM"
+else
+    cd "$REPO_DIR"
+    umask 022
+    "$@"
+fi

--- a/tests/smoke/mkosi.conf
+++ b/tests/smoke/mkosi.conf
@@ -1,0 +1,21 @@
+# minimal smoke-test image. validates the build toolchain (Lima VM, pinned
+# mkosi venv, sandbox, package download, output to the shared mount)
+
+[Distribution]
+Distribution=debian
+Release=trixie
+
+[Build]
+ToolsTree=default
+ToolsTreeDistribution=debian
+ToolsTreeRelease=trixie
+WithNetwork=true
+
+[Output]
+Format=tar
+ImageId=smoke
+OutputDirectory=mkosi.output
+
+[Content]
+Packages=bash
+Bootable=no


### PR DESCRIPTION
## What

Build and boot-test BuilderNet images on macOS (or any host without native mkosi) via Lima. mkosi only runs on Linux, and `trunk/buildernet` had no path for a Mac host.

**Make targets:** `make build` / `build-dev` / `build-local` build the images, `make smoke` builds a tiny image to validate the toolchain in a couple of minutes, `make boot` plus `make console` run the qemu image with a root shell, and `make clean` / `stop-vm` / `clean-vm` manage artifacts and the VM.

**`scripts/env_wrapper.sh`:** runs each command inside a per-repo Lima VM (named by a hash of the repo path, so multiple checkouts don't collide), with mkosi pinned to `.mkosi_version` in a venv. It rsyncs the repo to a VM-local dir because mkosi can't build on the virtiofs mount, then copies build artifacts back to `mkosi.output/`. On a Linux host, drop a `.bypass-lima` file in the repo root and it runs natively.

**`mkosi.sandbox/` apt retries:** snapshot.debian.org rate-limits and 503s; this makes apt retry each fetch with backoff instead of failing the whole build.
