### PR TITLE
Add more nftable metrics via socat/vector

### DIFF
--- a/mkosi.images/buildernet/mkosi.extra/etc/systemd/system/nftables-textfile-collector.service
+++ b/mkosi.images/buildernet/mkosi.extra/etc/systemd/system/nftables-textfile-collector.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Serve nftables ruleset metrics in Prometheus format.
+Wants=network-online.target
+After=network.target network-online.target nftables-load.service
+
+[Service]
+Type=exec
+DynamicUser=yes
+ExecStart=/usr/bin/socat -T5 TCP4-LISTEN:9116,bind=127.0.0.1,reuseaddr,fork EXEC:/usr/bin/nftables-textfile-collector
+Restart=on-failure
+AmbientCapabilities=CAP_NET_ADMIN
+CapabilityBoundingSet=CAP_NET_ADMIN
+NoNewPrivileges=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/mkosi.images/buildernet/mkosi.extra/usr/bin/nftables-textfile-collector
+++ b/mkosi.images/buildernet/mkosi.extra/usr/bin/nftables-textfile-collector
@@ -1,0 +1,58 @@
+#!/bin/bash
+# serves nftables metrics in Prometheus text format as one HTTP response.
+# invoked per-connection by socat (nftables-textfile-collector.service).
+# reads live counters so values are fresh at scrape time.
+set -u
+
+ENV_FILE="${NFT_ENV:-/etc/nftables/nftables.env}"
+getval() { grep -m1 "^$1=" "$ENV_FILE" 2>/dev/null | cut -d= -f2-; }
+
+emit() {
+  # nftables_up: is our ruleset actually loaded? 0 = fail-open
+  if nft list table inet filter >/dev/null 2>&1; then up=1; else up=0; fi
+  echo '# HELP nftables_up Whether the inet filter table is loaded (0 = rules absent).'
+  echo '# TYPE nftables_up gauge'
+  echo "nftables_up $up"
+
+  # configured limits (from the rendered env, independent of load state so a
+  # config/enforcement mismatch — thresholds present but nftables_up=0 — is visible)
+  cc_reg=$(getval total_conn_regular);        cc_priv=$(getval total_conn_privileged)
+  cr_reg=$(getval conn_rate_per_sec_regular); cr_priv=$(getval conn_rate_per_sec_privileged)
+  echo '# HELP nftables_conn_count_limit Configured max concurrent connections per source IP.'
+  echo '# TYPE nftables_conn_count_limit gauge'
+  [ -n "$cc_reg" ]  && echo "nftables_conn_count_limit{tier=\"regular\"} $cc_reg"
+  [ -n "$cc_priv" ] && echo "nftables_conn_count_limit{tier=\"privileged\"} $cc_priv"
+  echo '# HELP nftables_conn_rate_limit_per_second Configured max new connections/sec per source IP.'
+  echo '# TYPE nftables_conn_rate_limit_per_second gauge'
+  [ -n "$cr_reg" ]  && echo "nftables_conn_rate_limit_per_second{tier=\"regular\"} $cr_reg"
+  [ -n "$cr_priv" ] && echo "nftables_conn_rate_limit_per_second{tier=\"privileged\"} $cr_priv"
+
+  [ "$up" = 1 ] || return 0
+
+  # per-rule drop counters, keyed by the named counters in the ruleset.
+  # snapshot once, then emit each family grouped: the Prometheus text format
+  # requires all samples of a metric contiguous under its HELP/TYPE (interleaving
+  # packets/bytes lines is rejected by promtool and stricter parsers).
+  counters="$(nft -j list counters table inet filter 2>/dev/null)"
+  echo '# HELP nftables_rule_drop_packets_total Packets dropped, per named nftables rule.'
+  echo '# TYPE nftables_rule_drop_packets_total counter'
+  printf '%s' "$counters" | jq -r '.nftables[] | select(.counter) | .counter
+      | "nftables_rule_drop_packets_total{rule=\"\(.name)\"} \(.packets)"'
+  echo '# HELP nftables_rule_drop_bytes_total Bytes dropped, per named nftables rule.'
+  echo '# TYPE nftables_rule_drop_bytes_total counter'
+  printf '%s' "$counters" | jq -r '.nftables[] | select(.counter) | .counter
+      | "nftables_rule_drop_bytes_total{rule=\"\(.name)\"} \(.bytes)"'
+
+  # loaded allowlist size (0 with up=1 = allowlist did not render -> privileged
+  # senders silently fall to the regular tier). Cheap: interval set, few entries.
+  n=$(nft -j list set inet filter privileged_ips 2>/dev/null \
+      | jq '[.nftables[] | select(.set) | .set.elem // []] | add // [] | length')
+  [ -n "$n" ] || n=0
+  echo '# HELP nftables_privileged_ips Entries in the loaded privileged_ips allowlist set.'
+  echo '# TYPE nftables_privileged_ips gauge'
+  echo "nftables_privileged_ips $n"
+}
+
+body="$(emit)"$'\n'
+printf 'HTTP/1.1 200 OK\r\nContent-Type: text/plain; version=0.0.4\r\nContent-Length: %s\r\nConnection: close\r\n\r\n' "${#body}"
+printf '%s' "$body"

--- a/mkosi.images/buildernet/mkosi.extra/usr/lib/mustache-templates/etc/vector/vector.yaml.mustache_600
+++ b/mkosi.images/buildernet/mkosi.extra/usr/lib/mustache-templates/etc/vector/vector.yaml.mustache_600
@@ -45,6 +45,10 @@ sources:
     type: prometheus_scrape
     endpoints:
       - http://localhost:9115/
+  metrics_nftables:
+    type: prometheus_scrape
+    endpoints:
+      - http://localhost:9116/
 
 transforms:
   metrics_job_node_exporter:
@@ -101,6 +105,12 @@ transforms:
       - metrics_acme_le
     source: |-
       .tags.job = "acme-le"
+  metrics_job_nftables:
+    type: remap
+    inputs:
+      - metrics_nftables
+    source: |-
+      .tags.job = "nftables"
 
   haproxy_logs_filter:
     type: filter


### PR DESCRIPTION
## What

Export the nftables ruleset's drop counters as Prometheus metrics for connection-layer visibility.

**`nftables-textfile-collector`:** served over `127.0.0.1:9116` by socat, one HTTP response per scrape that reads the live counters (no on-disk `.prom` file to go stale). It emits `nftables_up` (0 means the ruleset is absent, i.e. haproxy is the only thing limiting), the configured limit gauges per tier, and `nftables_rule_drop_packets_total` / `_bytes_total` per named rule.

**vector:** scrapes `:9116` and ships the metrics tagged `job="nftables"`.

This complements node_exporter's default conntrack collector (table entries vs limit) with the per-rule drop detail that nft doesn't otherwise expose.

## Depends on

The nftables PR, whose ruleset defines the named counters this reads, so merge that first.

## Tested

Collector output verified locally: metrics render in Prometheus format with `nftables_up` and the limit gauges correct. End-to-end drop-counter scrape under load is covered by the nftables PR's final validation run.
