### PR TITLE
Add makefile command to get image hashes for portable measurement policies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ ifndef IMAGE
 	$(error IMAGE is not set. Please specify IMAGE=<image> when running make build or make build-dev)
 endif
 
-.PHONY: all build build-dev setup measure clean check-module
+.PHONY: all build build-dev setup measure measure-portable clean check-module
 
 # Default target
 all: build
@@ -51,6 +51,10 @@ build-dev: setup ## Build module with development tools
 measure: ## Export TDX measurements for the built EFI file
 	@$(WRAPPER) measured-boot $(FILE) build/measurements.json --direct-uki
 	echo "Measurements exported to build/measurements.json"
+
+measure-portable: ## Export portable measurements for the built EFI file
+	@$(WRAPPER) bash -c 'attest measure portable "$$1" > build/portable_measurements.json' _ "$(FILE)"
+	echo "Portable measurements exported to build/portable_measurements.json"
 
 measure-gcp: ## Export TDX measurements for GCP
 	@$(WRAPPER) dstack-mr -uki $(FILE) > build/gcp_measurements.json

--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ make measure
 
 This generates measurement files in the `build/` directory for attestation and verification.
 
+Alternatively, to get image hashes for 'portable measurement policies':
+
+```bash
+make measure-portable
+```
+
+This will create a file `build/portable_measurements.json` which can be used for [portable measurement policies](https://github.com/flashbots/attested-tls/tree/main/crates/attestation#portable-measurement-policies).
+
 ### Running Images
 
 **Add yourself to the kvm group** (to run QEMU without sudo):

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,26 @@
       };
       vendorHash = "sha256-glOyRTrIF/zP78XGV+v58a1Bec6C3Fvc5c8G3PglzPM=";
     };
+    attest-src = pkgs.fetchFromGitHub {
+      owner = "Easy-TEE";
+      repo = "attest";
+      rev = "e7f59c78f9eabd5d1ac7c9e96da46027878d038c";
+      hash = "sha256-4PKNsN8j2P6YJfzghz0U28+Bm3BhS/CveR/mSx3oUg8=";
+    };
+    attest = pkgs.rustPlatform.buildRustPackage {
+      pname = "attest";
+      version = "0.0.1";
+      src = attest-src;
+      cargoLock = {
+        lockFile = "${attest-src}/Cargo.lock";
+        outputHashes = {
+          "dcap-qvl-0.3.12" = "sha256-rLTp5wIhXRAcBtJb7lfd1TAg7yPRnwa0cBa1YT4LwKU=";
+          "cc-eventlog-0.5.8" = "sha256-KEauakj53LrhKTc0yYp5SM8ec0cFNm4YVuHCJYiPQjw=";
+        };
+      };
+      cargoBuildFlags = ["-p" "attest-cli" "--no-default-features"];
+      cargoTestFlags = ["-p" "attest-cli" "--no-default-features"];
+    };
     mkosi = system: let
       pkgsForSystem = import nixpkgs {inherit system;};
       mkosiTools = with pkgsForSystem; [
@@ -130,6 +150,7 @@
           (mkosi system)
           measured-boot
           measured-boot-gcp
+          attest
           bash
           curl
           git


### PR DESCRIPTION
This makes it possible to compute 'portable' image hashes for an OS image via a new makefile command `measure-portable`.

This uses [Easy-TEE/attest](https://github.com/Easy-TEE/attest) to compute these hashes, and adds the `attest` CLI to the nix development environment.

The computed hashes are written to a JSON file in the `build/` directory, similar to the other measurement-generating makefile commands.

My motivation for adding this is that i want to document an easy way to create these hashes for the upcoming release of `attested-tls-proxy` which supports these 'portable' policies - currently only on GCP.  See https://github.com/flashbots/attested-tls/tree/main/crates/attestation#portable-measurement-policies for details.