### PR TITLE
Bump kernel to 7.1.8 and refresh Debian snapshot

### DIFF
--- a/images/flashbox-l1.conf
+++ b/images/flashbox-l1.conf
@@ -8,4 +8,4 @@ Include=modules/flashbox/observability/mkosi.conf
 Profiles=azure,gcp
 
 [Distribution]
-Snapshot=20260430T025253Z
+Snapshot=20260728T082537Z

--- a/images/flashbox-l1.conf
+++ b/images/flashbox-l1.conf
@@ -8,4 +8,4 @@ Include=modules/flashbox/observability/mkosi.conf
 Profiles=azure,gcp
 
 [Distribution]
-Snapshot=20260812T085050Z
+Snapshot=20260814T023117Z

--- a/images/flashbox-l1.conf
+++ b/images/flashbox-l1.conf
@@ -8,4 +8,4 @@ Include=modules/flashbox/observability/mkosi.conf
 Profiles=azure,gcp
 
 [Distribution]
-Snapshot=20260728T082537Z
+Snapshot=20260812T085050Z

--- a/images/flashbox-l2.conf
+++ b/images/flashbox-l2.conf
@@ -7,4 +7,4 @@ Include=modules/flashbox/flashbox-l2/mkosi.conf
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260728T082537Z
+Snapshot=20260812T085050Z

--- a/images/flashbox-l2.conf
+++ b/images/flashbox-l2.conf
@@ -7,4 +7,4 @@ Include=modules/flashbox/flashbox-l2/mkosi.conf
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260430T025253Z
+Snapshot=20260728T082537Z

--- a/images/flashbox-l2.conf
+++ b/images/flashbox-l2.conf
@@ -7,4 +7,4 @@ Include=modules/flashbox/flashbox-l2/mkosi.conf
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260812T085050Z
+Snapshot=20260814T023117Z

--- a/images/l2-op-rbuilder-bproxy.conf
+++ b/images/l2-op-rbuilder-bproxy.conf
@@ -2,7 +2,7 @@
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260812T085050Z
+Snapshot=20260814T023117Z
 
 [Include]
 Include=shared/mkosi.conf

--- a/images/l2-op-rbuilder-bproxy.conf
+++ b/images/l2-op-rbuilder-bproxy.conf
@@ -2,7 +2,7 @@
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260430T025253Z
+Snapshot=20260728T082537Z
 
 [Include]
 Include=shared/mkosi.conf

--- a/images/l2-op-rbuilder-bproxy.conf
+++ b/images/l2-op-rbuilder-bproxy.conf
@@ -2,7 +2,7 @@
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260728T082537Z
+Snapshot=20260812T085050Z
 
 [Include]
 Include=shared/mkosi.conf

--- a/images/l2-op-rbuilder.conf
+++ b/images/l2-op-rbuilder.conf
@@ -2,7 +2,7 @@
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260812T085050Z
+Snapshot=20260814T023117Z
 
 [Include]
 Include=shared/mkosi.conf

--- a/images/l2-op-rbuilder.conf
+++ b/images/l2-op-rbuilder.conf
@@ -2,7 +2,7 @@
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260430T025253Z
+Snapshot=20260728T082537Z
 
 [Include]
 Include=shared/mkosi.conf

--- a/images/l2-op-rbuilder.conf
+++ b/images/l2-op-rbuilder.conf
@@ -2,7 +2,7 @@
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260728T082537Z
+Snapshot=20260812T085050Z
 
 [Include]
 Include=shared/mkosi.conf

--- a/images/l2-simulator.conf
+++ b/images/l2-simulator.conf
@@ -2,7 +2,7 @@
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260812T085050Z
+Snapshot=20260814T023117Z
 
 [Include]
 Include=shared/mkosi.conf

--- a/images/l2-simulator.conf
+++ b/images/l2-simulator.conf
@@ -2,7 +2,7 @@
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260430T025253Z
+Snapshot=20260728T082537Z
 
 [Include]
 Include=shared/mkosi.conf

--- a/images/l2-simulator.conf
+++ b/images/l2-simulator.conf
@@ -2,7 +2,7 @@
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260728T082537Z
+Snapshot=20260812T085050Z
 
 [Include]
 Include=shared/mkosi.conf

--- a/shared/mkosi.apt.conf
+++ b/shared/mkosi.apt.conf
@@ -1,0 +1,5 @@
+# Trim apt download volume and tolerate transient failures — index fetches
+# go through lima's user-mode network and are written to mkosi.cache over
+# the reverse-sshfs mount, so every megabyte counts.
+Acquire::Languages "none";
+Acquire::Retries "3";

--- a/shared/mkosi.build.d/10-kernel.sh
+++ b/shared/mkosi.build.d/10-kernel.sh
@@ -3,18 +3,23 @@ set -euxo pipefail
 shopt -s inherit_errexit  # propagate errexit to $() subshells
 shopt -s nullglob         # non-matching globs expand to nothing
 
-# KERNEL_VERSION must be set (Debian major.minor, e.g. "6.16").
+# KERNEL_VERSION must be set (Debian major.minor, e.g. "7.1").
 # Must match a linux-source package available in the pinned snapshot mirror.
+# KERNEL_APT_SUITE selects the suite the package is installed from
+# (default: <release>-backports; set to "sid" when the wanted point release
+# has not been built for backports yet).
 if [[ -z "${KERNEL_VERSION:-}" ]]; then
-    echo "ERROR: KERNEL_VERSION is not set. Set it in mkosi.conf Environment= (e.g. KERNEL_VERSION=6.16)" >&2
+    echo "ERROR: KERNEL_VERSION is not set. Set it in mkosi.conf Environment= (e.g. KERNEL_VERSION=7.1)" >&2
     exit 1
 fi
 
 # Read distribution info from mkosi config JSON
 snapshot=$(jq -r '.Snapshot' "$MKOSI_CONFIG")
 release=$(jq -re '.Release' "$MKOSI_CONFIG")
+kernel_suite="${KERNEL_APT_SUITE:-${release}-backports}"
 echo "Snapshot: $snapshot"
 echo "Release: $release"
+echo "Kernel apt suite: $kernel_suite"
 
 # Auto-discover config fragments from registered directories
 # KERNEL_CONFIG_SNIPPETS is processed first, then KERNEL_CONFIG_SNIPPETS_* in alphabetical order
@@ -45,6 +50,7 @@ cache_hash=$(
     { echo "KERNEL_VERSION=${KERNEL_VERSION}"; \
       echo "LOCALVERSION=${LOCALVERSION}"; \
       echo "SNAPSHOT=${snapshot}"; \
+      echo "SUITE=${kernel_suite}"; \
       cat -- "${config_paths[@]}" "${patch_paths[@]}"; } \
     | sha256sum | cut -d' ' -f1 | cut -c1-12
 )
@@ -73,7 +79,7 @@ else
     kernel_src_dir="${BUILDROOT}${chroot_kernel_src_dir}"
     kconfig_dir="${BUILDROOT}${chroot_kconfig_dir}"
 
-    apt-get -y install "linux-source-${KERNEL_VERSION}/${release}-backports" --install-recommends
+    apt-get -y install "linux-source-${KERNEL_VERSION}/${kernel_suite}" --install-recommends
 
     source_tarball="${BUILDROOT}/usr/src/linux-source-${KERNEL_VERSION}.tar.xz"
     if [[ ! -f "${source_tarball}" ]]; then

--- a/shared/mkosi.conf
+++ b/shared/mkosi.conf
@@ -6,7 +6,10 @@ Release=trixie
 [Build]
 PackageCacheDirectory=mkosi.cache
 SandboxTrees=mkosi.builddir/mkosi.sources:/etc/apt/sources.list.d/mkosi.sources
-Environment=KERNEL_VERSION=6.19
+             shared/mkosi.pref:/etc/apt/preferences.d/mkosi.pref
+             shared/mkosi.apt.conf:/etc/apt/apt.conf.d/99mkosi.conf
+Environment=KERNEL_VERSION=7.1
+            KERNEL_APT_SUITE=sid
             KERNEL_CONFIG_SNIPPETS=shared/kernel/config.d
             KERNEL_PATCHES=shared/kernel/patches
 WithNetwork=true

--- a/shared/mkosi.pref
+++ b/shared/mkosi.pref
@@ -1,0 +1,6 @@
+# Pin sid below the release suites so it is never used for dependency
+# resolution unless a package is explicitly requested from it
+# (e.g. linux-source via KERNEL_APT_SUITE=sid in 10-kernel.sh).
+Package: *
+Pin: release n=sid
+Pin-Priority: 100

--- a/shared/mkosi.sync.d/10-setup-apt.sh
+++ b/shared/mkosi.sync.d/10-setup-apt.sh
@@ -14,4 +14,12 @@ URIs: $MIRROR
 Suites: ${RELEASE} ${RELEASE}-backports
 Components: main
 Trusted: yes
+
+# deb only (no deb-src): sid is used solely to fetch the linux-source
+# binary package, and its Sources index alone is ~12 MB per apt update.
+Types: deb
+URIs: $MIRROR
+Suites: sid
+Components: main
+Trusted: yes
 EOF


### PR DESCRIPTION
Kernel 6.19 is EOL (last release 6.19.14, 2026-04-22) so recent CVE fixes no longer land in that series. Move to 7.1, the current upstream stable series, at point release 7.1.5.

trixie-backports only carries 7.1.3-1~bpo13+1, so the linux-source package is fetched from sid instead, where 7.1.8 is available:

- add sid (binary packages only) to the mkosi apt sources, pinned to priority 100 via shared/mkosi.pref so no package ever resolves from it unless explicitly requested
- make the suite linux-source is installed from configurable via KERNEL_APT_SUITE (default: <release>-backports), set to sid, and include it in the kernel cache key
- add shared/mkosi.apt.conf: skip translation indices and retry transient download failures

Snapshot bumped 20260430T025253Z -> 20260814T023117Z across all images, which also picks up ~3 months of trixie userspace updates. Once a >=7.1.5 backport lands in trixie-backports, KERNEL_APT_SUITE can be dropped again.

Here is a screenshot from a dev-image running locally in qemu:
<img width="791" height="93" alt="image" src="https://github.com/user-attachments/assets/7ca99d34-2665-4995-b647-56400e0129b0" />
