### PR TITLE
Buildernet - Bump attested-tls-proxy to 2.0.1 and use 'portable' measurements

### DIFF
--- a/.github/workflows/_release-buildernet-image.yml
+++ b/.github/workflows/_release-buildernet-image.yml
@@ -23,6 +23,10 @@ on:
         description: "R2 cache object name (e.g. 'cache' or 'cache-playground')"
         type: string
         required: true
+      portable-measurements:
+        description: "Generate portable measurements for the published GCP UKI"
+        type: boolean
+        default: true
 
 jobs:
   build:
@@ -130,6 +134,21 @@ jobs:
             ARGS+=(--profile="${{ inputs.mkosi-profile }}")
           fi
           mkosi "${ARGS[@]}"
+
+      - name: Install portable measurement tool
+        if: inputs.portable-measurements
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Generate portable measurements
+        if: inputs.portable-measurements
+        env:
+          ATTEST_REV: e7f59c78f9eabd5d1ac7c9e96da46027878d038c
+        run: |
+          cargo install --locked --git https://github.com/Easy-TEE/attest \
+            --rev "${ATTEST_REV}" --package attest-cli --no-default-features
+          make measure-portable \
+            UKI_FILE="mkosi.output/buildernet-gcp_${IMAGE_VERSION}.efi" \
+            MEASUREMENTS_FILE="mkosi.output/buildernet-${IMAGE_VERSION}-portable-measurements.json"
 
       - name: Prepare cache
         run: |

--- a/.github/workflows/release-playground.yml
+++ b/.github/workflows/release-playground.yml
@@ -16,4 +16,5 @@ jobs:
       checksum-globs: "buildernet-*.qcow2"
       r2-include: "buildernet-*.{qcow2,minisig,sha256}"
       cache-name: "cache-playground"
+      portable-measurements: false
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     uses: ./.github/workflows/_release-buildernet-image.yml
     with:
       r2-path-prefix: "buildernet-images"
-      checksum-globs: "buildernet-*.{efi,tar.gz,vhd,qcow2}"
-      r2-include: "buildernet-*.{efi,tar.gz,vhd,qcow2,minisig,sha256}"
+      checksum-globs: "buildernet-*.{efi,tar.gz,vhd,qcow2,json}"
+      r2-include: "buildernet-*.{efi,tar.gz,vhd,qcow2,minisig,sha256,json}"
       cache-name: "cache"
     secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ tmp/
 !/**/.gitkeep
 .vscode/
 CLAUDE.local.md
+/.bypass-lima

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 
 SHELL := /usr/bin/env bash
 WRAPPER := scripts/env_wrapper.sh
+UKI_FILE ?= mkosi.output/buildernet-gcp_latest.efi
+MEASUREMENTS_FILE ?= mkosi.output/portable_measurements.json
 
 # Lima build VM name, mirroring scripts/env_wrapper.sh: tee-builder-<sha256(repo path)[:8]>.
 ifndef LIMA_VM
@@ -21,7 +23,7 @@ help: ## display their help.
 
 ##@ Build
 
-.PHONY: build build-dev build-local smoke boot clean clean-vm stop-vm
+.PHONY: build build-dev build-local smoke measure-portable boot clean clean-vm stop-vm
 
 build: ## build all BuilderNet images (azure, gcp, qemu)
 	$(WRAPPER) mkosi $(ARCH) --force -I buildernet.conf build
@@ -35,6 +37,12 @@ build-local: ## build with local+devtools profiles (root autologin console, for 
 smoke: ## tiny quick image build to validate the toolchain 
 	$(WRAPPER) mkosi -C tests/smoke --force build
 	@echo "Smoke build OK"
+
+measure-portable: ## export portable measurements for the GCP UKI (override UKI_FILE=...)
+	@mkdir -p "$(dir $(MEASUREMENTS_FILE))"
+	@command -v attest >/dev/null || { echo "attest not found; install Easy-TEE/attest from main" >&2; exit 1; }
+	@attest measure portable --no-azure "$(UKI_FILE)" > "$(MEASUREMENTS_FILE)"
+	@echo "Portable measurements exported to $(MEASUREMENTS_FILE)"
 
 ##@ Run
 

--- a/README.md
+++ b/README.md
@@ -74,47 +74,47 @@ To verify that our official images are built from the corresponding git revision
 4. Calculate the SHA256 hashsum of the *.efi image in the `mkosi.output` directory. It should match the hashsum from the *.sha256 file from https://downloads.buildernet.org
 
 # Measurements
-Measurement are a way to verify that the image you built offline matches the one running as a VM.
 
-To measure a Azure image:
-1. Clone github.com/flashbots/measured-boot/ repo and build the `measured-boot` script
+Portable measurements let you verify that a BuilderNet GCP VM is running the OS image
+you audited and built locally, without depending on GCP-specific TDX measurement values.
+
+Build the images, install the `attest` CLI from
+[`Easy-TEE/attest`](https://github.com/Easy-TEE/attest) `main` (pinned below to its current
+head for reproducibility), and measure the GCP UKI:
+
+```bash
+make build
+cargo install --locked --git https://github.com/Easy-TEE/attest \
+  --rev e7f59c78f9eabd5d1ac7c9e96da46027878d038c \
+  --package attest-cli --no-default-features
+make measure-portable
 ```
-go build
+
+This writes `mkosi.output/portable_measurements.json`. To measure another UKI or choose a
+different output path, set `UKI_FILE` or `MEASUREMENTS_FILE`:
+
+```bash
+make measure-portable \
+  UKI_FILE=mkosi.output/buildernet-gcp_2.9.1-deadbeef.efi \
+  MEASUREMENTS_FILE=mkosi.output/portable_measurements.json
 ```
-2. Measure the image offline
-```
-./measured-boot image.efi /dev/null --direct-uki
-```
-3. Clone https://github.com/flashbots/attested-tls-proxy.git repo and run the `attested-get` tool
-```
-git clone https://github.com/flashbots/attested-tls-proxy.git
+
+For a release build, compare this file with the
+`buildernet-<version>-portable-measurements.json` file published alongside the image.
+
+To attest a running VM against those image hashes, build `attested-get` from
+[`flashbots/attested-tls-proxy`](https://github.com/flashbots/attested-tls-proxy):
+
+```bash
+git clone https://github.com/flashbots/attested-tls-proxy
 cd attested-tls-proxy
-curl -fSsL https://measurements.buildernet.org > /tmp/measurements-buildernet.json
-
 cargo run -- attested-get \
-  --measurements-file /tmp/measurements-buildernet.json \
-  https://_BUILDERNET_INSTANCE_:7936
+  --measurements-file ../flashbots-images/mkosi.output/portable_measurements.json \
+  https://<buildernet-instance>:7936
 ```
-1. Compare PCRs 4 and 11 of the offline image and the deployed one, they should match.
 
-To measure a GCP image:
-1. Clone github.com/flashbots/dstack-mr-gcp repo and build the `dstack-mr` tool
-```
-go build
-```
-2. Measure the image offline
-```
-./dstack-mr -uki buildernet-gcp.efi
-```
-3. Clone github.com/flashbots/cvm-reverse-proxy repo and build the `attested-get` tool
-```
-go build cmd/attested-get/main.go
-```
-4. Measure the deployed image
-```
-./attested-get --addr=https://<instance IP>:7936
-```
-5. Compare PCRs 0-4 of the offline image and the deployed one, they should match.
+Successful verification means the VM's attestation matches the hashes derived from your
+locally built image.
 
 # Development
 - Use standard directory names of `mkosi` so that it can automatically pick it up.

--- a/mkosi.images/buildernet/mkosi.build.d/15-attested-tls-proxy.sh.chroot
+++ b/mkosi.images/buildernet/mkosi.build.d/15-attested-tls-proxy.sh.chroot
@@ -3,8 +3,8 @@ set -euo pipefail
 
 echo "Installing attested-tls-proxy..."
 
-VERSION="v1.1.2"
-EXPECTED_SHA256=3b1b1868a5fcb1c0a0b07cfa32a76d2c609c99b9705596cc4a528659208d0349
+VERSION="v2.0.1"
+EXPECTED_SHA256=2c8f9f720a103f9d9cc1b53a0726b77f9310175057394cc4b2d5c565e49d849f
 curl -sSfL https://github.com/flashbots/attested-tls-proxy/releases/download/${VERSION}/attested-tls-proxy_1.${VERSION}_amd64.deb \
   -o $PACKAGEDIR/attested-tls-proxy.deb
 echo "${EXPECTED_SHA256}" $PACKAGEDIR/attested-tls-proxy.deb | sha256sum --check


### PR DESCRIPTION
**Note** this is a **protocol breaking change** meaning Builderhub also needs updating to latest version of `attested-tls-proxy` via the devops repo.

This updates the Buildernet branch to use the latest version of `attested-tls-proxy`, which supports specifying measurements as OS image hashes rather than TDX register values.

Edit: i realised there is an issue with this - Builderhub internally checks measurements given in HTTP headers rather than using  attested-tls-proxy for validation.  So it wont work as is.

These hashes are created from the build image using the [Easy-TEE/attest](https://github.com/Easy-TEE/attest) CLI tool.  A Makefile command is included to make it easier to run this.  During attestation verification, the verifier computes the expected register values based on these hashes together with 'platform metadata' provided by the attester.

The idea is to avoid getting attestation failures when Google update their firmware, or we use a different zone or hardware configuration.

The release pipeline is updated to include these image hashes as a release asset.

I have tested that i can build the image and compute hashes, but not actually deployed a node and seen a successful attestation.

One thing that might be useful to be able to quickly see if we can verify measurements is to port https://github.com/flashbots/flashbots-images/pull/143 to `trunk/buildernet` so that we log measurement registers at boot.

Here are the hashes i get from building on this branch:
```json
{
  "azure": null,
  "dcap": {
    "cmdline_hash": "cf0ee3a3339203ad6867a2c8726d20d182867a0d219f69a20c3fbad44181290cf920d8f4f40fb200a47cab06696d9888",
    "gpt_disk_guid_hash": "585c427b06446617e5d91cc05436f2ea46c5ff733261e6a7073785d5a5d13462527ad171d6efa706b44ca4268e69925f",
    "initrd_hash": "518bd1ff5dc4d6dbc644d2bb007f4a1fd73e6b0232fa5c3f3f6d5dff0b0ced1238a1ec34f09df3f18a5bafd2ba26c127",
    "kernel_authenticode": "3b2ec1ef0dcfd378f46a389de1c66b82176966acad81e4e7c6640cb3f3c62f018550db1eaa30ac1632b3d387e7465471",
    "uki_authenticode": "823b45cd4cd22222161ccb5d267325f48c156dd1be521059051c201efa96e6302e0aabd529335b46bdb1d43669f2f599"
  },
  "kind": "portable"
}
```