### PR TITLE
Support newer systemd-efi-stubs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,7 @@
         findutils
         gnused
         gnugrep
+        gawk
         gnutar
         gzip
         xz

--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,7 @@
         erofs-utils
         mtools
         gptfdisk
+        binutils
         util-linux
         zstd
         which

--- a/shared/mkosi.conf
+++ b/shared/mkosi.conf
@@ -25,6 +25,7 @@ BuildScripts=shared/mkosi.build.d/*
 SyncScripts=shared/mkosi.sync.d/*
 PostInstallationScripts=shared/mkosi.postinst.d/*
 FinalizeScripts=shared/mkosi.finalize.d/*
+PostOutputScripts=shared/mkosi.postoutput.d/*
 
 CleanPackageMetadata=true
 # Kernel .deb built by the kernel build script and placed in $PACKAGEDIR

--- a/shared/mkosi.postinst.d/10-efi-stub.sh
+++ b/shared/mkosi.postinst.d/10-efi-stub.sh
@@ -1,13 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Use a version of systemd-boot that is compatible with measured-boot script
-SYSTEMD_BOOT_URL="https://snapshot.debian.org/archive/debian/20240314T094714Z/pool/main/s/systemd/systemd-boot-efi_255.4-1_amd64.deb"
-TEMP_DEB="$BUILDROOT/systemd-boot.deb"
-curl -L -o "$TEMP_DEB" "$SYSTEMD_BOOT_URL"
-mkosi-chroot dpkg -i /systemd-boot.deb
-rm -f "$TEMP_DEB"
-
 # Copy the efi stub to the place where bootctl expects it
 bootctl="$(which -a bootctl | grep /nix | head -n 1)"
 nix_dir="$(dirname $(dirname $bootctl))"

--- a/shared/mkosi.postoutput.d/00-strip-osrel.sh
+++ b/shared/mkosi.postoutput.d/00-strip-osrel.sh
@@ -4,10 +4,7 @@ export SOURCE_DATE_EPOCH=0
 
 # systemd-stub > 255 merges .osrel section into initrd at runtime
 # This removes .osrel to make initrd contents deterministic
-shopt -s nullglob
-for uki in "$OUTPUTDIR"/*.efi; do
-    objcopy --remove-section=.osrel "${OUTPUTDIR}/${IMAGE_ID}_${IMAGE_VERSION}.efi"
-done
+objcopy --remove-section=.osrel "${OUTPUTDIR}/${IMAGE_ID}_${IMAGE_VERSION}.efi"
 
 # For dm-verity the UKI is embedded in the ESP
 for raw in "$OUTPUTDIR"/*.raw; do

--- a/shared/mkosi.postoutput.d/00-strip-osrel.sh
+++ b/shared/mkosi.postoutput.d/00-strip-osrel.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# systemd-stub > 255 merges .osrel section into initrd at runtime
+# This removes .osrel to make initrd contents deterministic
+shopt -s nullglob
+for uki in "$OUTPUTDIR"/*.efi; do
+    objcopy --remove-section=.osrel "${OUTPUTDIR}/${IMAGE_ID}_${IMAGE_VERSION}.efi"
+done

--- a/shared/mkosi.postoutput.d/00-strip-osrel.sh
+++ b/shared/mkosi.postoutput.d/00-strip-osrel.sh
@@ -1,9 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
+export SOURCE_DATE_EPOCH=0
 
 # systemd-stub > 255 merges .osrel section into initrd at runtime
 # This removes .osrel to make initrd contents deterministic
 shopt -s nullglob
 for uki in "$OUTPUTDIR"/*.efi; do
     objcopy --remove-section=.osrel "${OUTPUTDIR}/${IMAGE_ID}_${IMAGE_VERSION}.efi"
+done
+
+# For dm-verity the UKI is embedded in the ESP
+for raw in "$OUTPUTDIR"/*.raw; do
+    uki="${raw%.raw}.efi"
+    [ -f "$uki" ] || continue
+    start=$(sgdisk -p "$raw" | awk '$6 == "EF00" { print $2; exit }')
+    [ -n "$start" ] || continue
+    mcopy -o -i "$raw@@$((start * 512))" "$uki" ::EFI/BOOT/BOOTX64.EFI
 done


### PR DESCRIPTION
This removes the line in the code that was pinning us to the latest EFI stub, since the latest version of attest will now support different bootloader and UEFI versions. In order to make this work, I had to remove the `.osrel` PE section from the uki file, since the latest systemd-stub merges it into the initrd before measuring RTMR2, meaning with .osrel + recent systemd-efi, I'd have to do all sorts of weird merging logic with cpio to calculate the expected initrd measurement