### PR TITLE
(BuilderNet) Update Systemd EFI stub

### DIFF
--- a/buildernet.conf
+++ b/buildernet.conf
@@ -15,6 +15,7 @@ ToolsTreeDistribution=debian
 ToolsTreeRelease=trixie
 ToolsTreePackages=qemu-utils
                   gdisk
+                  binutils
 WithNetwork=true
 
 [Content]

--- a/mkosi.images/buildernet-azure/mkosi.postoutput
+++ b/mkosi.images/buildernet-azure/mkosi.postoutput
@@ -3,6 +3,7 @@
 set -eu -o pipefail
 
 export SOURCE_DATE_EPOCH=0 # not propagated from the main config, needed for mkfs.vfat
+objcopy --remove-section=.osrel ${OUTPUTDIR}/${IMAGE_ID}_${IMAGE_VERSION}.efi
 mkdir -p ${OUTPUTDIR}/esp/EFI/BOOT
 cp ${OUTPUTDIR}/${IMAGE_ID}_${IMAGE_VERSION}.efi ${OUTPUTDIR}/esp/EFI/BOOT/BOOTX64.EFI
 rm -f ${OUTPUTDIR}/${IMAGE_ID}.raw

--- a/mkosi.images/buildernet-gcp/mkosi.postinst
+++ b/mkosi.images/buildernet-gcp/mkosi.postinst
@@ -20,9 +20,3 @@ for var in "${!BUILDERNET_@}"; do
       ;;
   esac
 done
-
-SYSTEMD_BOOT_URL="https://snapshot.debian.org/archive/debian/20240314T094714Z/pool/main/s/systemd/systemd-boot-efi_255.4-1_amd64.deb"
-TEMP_DEB="$BUILDROOT/systemd-boot.deb"
-curl -L -o "$TEMP_DEB" "$SYSTEMD_BOOT_URL"
-mkosi-chroot dpkg -i /systemd-boot.deb
-rm -f "$TEMP_DEB"

--- a/mkosi.images/buildernet-gcp/mkosi.postoutput
+++ b/mkosi.images/buildernet-gcp/mkosi.postoutput
@@ -4,6 +4,7 @@ set -eu -o pipefail
 
 export SOURCE_DATE_EPOCH=0 # not propagated from the main config, needed for mkfs.vfat
 export SYSTEMD_REPART_MKFS_OPTIONS_VFAT="-i 12345678 --invariant"
+objcopy --remove-section=.osrel ${OUTPUTDIR}/${IMAGE_ID}_${IMAGE_VERSION}.efi
 mkdir -p ${OUTPUTDIR}/esp/EFI/BOOT
 cp ${OUTPUTDIR}/${IMAGE_ID}_${IMAGE_VERSION}.efi ${OUTPUTDIR}/esp/EFI/BOOT/BOOTX64.EFI
 # Set fixed timestamps for reproducibility (FAT uses file mtime for directory entries)

--- a/mkosi.images/buildernet-qemu/mkosi.postoutput
+++ b/mkosi.images/buildernet-qemu/mkosi.postoutput
@@ -4,6 +4,7 @@ set -eu -o pipefail
 
 export SOURCE_DATE_EPOCH=0 # not propagated from the main config, needed for mkfs.vfat
 export SYSTEMD_REPART_MKFS_OPTIONS_VFAT="-i 12345678"
+objcopy --remove-section=.osrel ${OUTPUTDIR}/${IMAGE_ID}_${IMAGE_VERSION}.efi
 mkdir -p ${OUTPUTDIR}/esp/EFI/BOOT
 cp ${OUTPUTDIR}/${IMAGE_ID}_${IMAGE_VERSION}.efi ${OUTPUTDIR}/esp/EFI/BOOT/BOOTX64.EFI
 rm -f ${OUTPUTDIR}/${IMAGE_ID}_${IMAGE_VERSION}.raw


### PR DESCRIPTION
This PR updates the EFI stub to the latest version (since attest supports it now) and removes the .osrel section from the UKI file, which causes reproducibility issues on newer systemd efi stub versions