### PR TITLE
Bump kernel 6.19 -> 7.1.8 and refresh Debian snapshot (L2 cherry-pick of #186)"

### DIFF
--- a/images/flashbox-l1.conf
+++ b/images/flashbox-l1.conf
@@ -7,4 +7,4 @@ Include=modules/flashbox/flashbox-l1/mkosi.conf
 Profiles=azure,gcp
 
 [Distribution]
-Snapshot=20260728T082537Z
+Snapshot=20260812T085050Z

--- a/images/flashbox-l1.conf
+++ b/images/flashbox-l1.conf
@@ -7,4 +7,4 @@ Include=modules/flashbox/flashbox-l1/mkosi.conf
 Profiles=azure,gcp
 
 [Distribution]
-Snapshot=20260430T025253Z
+Snapshot=20260728T082537Z

--- a/images/flashbox-l1.conf
+++ b/images/flashbox-l1.conf
@@ -7,4 +7,4 @@ Include=modules/flashbox/flashbox-l1/mkosi.conf
 Profiles=azure,gcp
 
 [Distribution]
-Snapshot=20260812T085050Z
+Snapshot=20260814T023117Z

--- a/images/flashbox-l2.conf
+++ b/images/flashbox-l2.conf
@@ -7,4 +7,4 @@ Include=modules/flashbox/flashbox-l2/mkosi.conf
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260728T082537Z
+Snapshot=20260812T085050Z

--- a/images/flashbox-l2.conf
+++ b/images/flashbox-l2.conf
@@ -7,4 +7,4 @@ Include=modules/flashbox/flashbox-l2/mkosi.conf
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260430T025253Z
+Snapshot=20260728T082537Z

--- a/images/flashbox-l2.conf
+++ b/images/flashbox-l2.conf
@@ -7,4 +7,4 @@ Include=modules/flashbox/flashbox-l2/mkosi.conf
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260812T085050Z
+Snapshot=20260814T023117Z

--- a/images/l2-op-rbuilder-bproxy.conf
+++ b/images/l2-op-rbuilder-bproxy.conf
@@ -2,7 +2,7 @@
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260812T085050Z
+Snapshot=20260814T023117Z
 
 [Include]
 Include=shared/mkosi.conf

--- a/images/l2-op-rbuilder-bproxy.conf
+++ b/images/l2-op-rbuilder-bproxy.conf
@@ -2,7 +2,7 @@
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260430T025253Z
+Snapshot=20260728T082537Z
 
 [Include]
 Include=shared/mkosi.conf

--- a/images/l2-op-rbuilder-bproxy.conf
+++ b/images/l2-op-rbuilder-bproxy.conf
@@ -2,7 +2,7 @@
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260728T082537Z
+Snapshot=20260812T085050Z
 
 [Include]
 Include=shared/mkosi.conf

--- a/images/l2-op-rbuilder.conf
+++ b/images/l2-op-rbuilder.conf
@@ -2,7 +2,7 @@
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260812T085050Z
+Snapshot=20260814T023117Z
 
 [Include]
 Include=shared/mkosi.conf

--- a/images/l2-op-rbuilder.conf
+++ b/images/l2-op-rbuilder.conf
@@ -2,7 +2,7 @@
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260430T025253Z
+Snapshot=20260728T082537Z
 
 [Include]
 Include=shared/mkosi.conf

--- a/images/l2-op-rbuilder.conf
+++ b/images/l2-op-rbuilder.conf
@@ -2,7 +2,7 @@
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260728T082537Z
+Snapshot=20260812T085050Z
 
 [Include]
 Include=shared/mkosi.conf

--- a/images/l2-simulator.conf
+++ b/images/l2-simulator.conf
@@ -2,7 +2,7 @@
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260812T085050Z
+Snapshot=20260814T023117Z
 
 [Include]
 Include=shared/mkosi.conf

--- a/images/l2-simulator.conf
+++ b/images/l2-simulator.conf
@@ -2,7 +2,7 @@
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260430T025253Z
+Snapshot=20260728T082537Z
 
 [Include]
 Include=shared/mkosi.conf

--- a/images/l2-simulator.conf
+++ b/images/l2-simulator.conf
@@ -2,7 +2,7 @@
 Profiles=gcp
 
 [Distribution]
-Snapshot=20260728T082537Z
+Snapshot=20260812T085050Z
 
 [Include]
 Include=shared/mkosi.conf

--- a/shared/mkosi.apt.conf
+++ b/shared/mkosi.apt.conf
@@ -1,0 +1,5 @@
+# Trim apt download volume and tolerate transient failures — index fetches
+# go through lima's user-mode network and are written to mkosi.cache over
+# the reverse-sshfs mount, so every megabyte counts.
+Acquire::Languages "none";
+Acquire::Retries "3";

--- a/shared/mkosi.build.d/10-kernel.sh
+++ b/shared/mkosi.build.d/10-kernel.sh
@@ -3,18 +3,23 @@ set -euxo pipefail
 shopt -s inherit_errexit  # propagate errexit to $() subshells
 shopt -s nullglob         # non-matching globs expand to nothing
 
-# KERNEL_VERSION must be set (Debian major.minor, e.g. "6.16").
+# KERNEL_VERSION must be set (Debian major.minor, e.g. "7.1").
 # Must match a linux-source package available in the pinned snapshot mirror.
+# KERNEL_APT_SUITE selects the suite the package is installed from
+# (default: <release>-backports; set to "sid" when the wanted point release
+# has not been built for backports yet).
 if [[ -z "${KERNEL_VERSION:-}" ]]; then
-    echo "ERROR: KERNEL_VERSION is not set. Set it in mkosi.conf Environment= (e.g. KERNEL_VERSION=6.16)" >&2
+    echo "ERROR: KERNEL_VERSION is not set. Set it in mkosi.conf Environment= (e.g. KERNEL_VERSION=7.1)" >&2
     exit 1
 fi
 
 # Read distribution info from mkosi config JSON
 snapshot=$(jq -r '.Snapshot' "$MKOSI_CONFIG")
 release=$(jq -re '.Release' "$MKOSI_CONFIG")
+kernel_suite="${KERNEL_APT_SUITE:-${release}-backports}"
 echo "Snapshot: $snapshot"
 echo "Release: $release"
+echo "Kernel apt suite: $kernel_suite"
 
 # Auto-discover config fragments from registered directories
 # KERNEL_CONFIG_SNIPPETS is processed first, then KERNEL_CONFIG_SNIPPETS_* in alphabetical order
@@ -45,6 +50,7 @@ cache_hash=$(
     { echo "KERNEL_VERSION=${KERNEL_VERSION}"; \
       echo "LOCALVERSION=${LOCALVERSION}"; \
       echo "SNAPSHOT=${snapshot}"; \
+      echo "SUITE=${kernel_suite}"; \
       cat -- "${config_paths[@]}" "${patch_paths[@]}"; } \
     | sha256sum | cut -d' ' -f1 | cut -c1-12
 )
@@ -73,7 +79,7 @@ else
     kernel_src_dir="${BUILDROOT}${chroot_kernel_src_dir}"
     kconfig_dir="${BUILDROOT}${chroot_kconfig_dir}"
 
-    apt-get -y install "linux-source-${KERNEL_VERSION}/${release}-backports" --install-recommends
+    apt-get -y install "linux-source-${KERNEL_VERSION}/${kernel_suite}" --install-recommends
 
     source_tarball="${BUILDROOT}/usr/src/linux-source-${KERNEL_VERSION}.tar.xz"
     if [[ ! -f "${source_tarball}" ]]; then

--- a/shared/mkosi.conf
+++ b/shared/mkosi.conf
@@ -6,7 +6,10 @@ Release=trixie
 [Build]
 PackageCacheDirectory=mkosi.cache
 SandboxTrees=mkosi.builddir/mkosi.sources:/etc/apt/sources.list.d/mkosi.sources
-Environment=KERNEL_VERSION=6.19
+             shared/mkosi.pref:/etc/apt/preferences.d/mkosi.pref
+             shared/mkosi.apt.conf:/etc/apt/apt.conf.d/99mkosi.conf
+Environment=KERNEL_VERSION=7.1
+            KERNEL_APT_SUITE=sid
             KERNEL_CONFIG_SNIPPETS=shared/kernel/config.d
             KERNEL_PATCHES=shared/kernel/patches
 WithNetwork=true

--- a/shared/mkosi.finalize.d/90-debloat.sh
+++ b/shared/mkosi.finalize.d/90-debloat.sh
@@ -44,6 +44,7 @@ debloat_paths=(
     "/var/lib/ucf"
     "/etc/credstore"
     "/nix"
+    "/var/lib/dpkg/info"
 )
 
 if [[ ! "${PROFILES:-}" == *"devtools"* ]]; then

--- a/shared/mkosi.pref
+++ b/shared/mkosi.pref
@@ -1,0 +1,6 @@
+# Pin sid below the release suites so it is never used for dependency
+# resolution unless a package is explicitly requested from it
+# (e.g. linux-source via KERNEL_APT_SUITE=sid in 10-kernel.sh).
+Package: *
+Pin: release n=sid
+Pin-Priority: 100

--- a/shared/mkosi.sync.d/10-setup-apt.sh
+++ b/shared/mkosi.sync.d/10-setup-apt.sh
@@ -14,4 +14,12 @@ URIs: $MIRROR
 Suites: ${RELEASE} ${RELEASE}-backports
 Components: main
 Trusted: yes
+
+# deb only (no deb-src): sid is used solely to fetch the linux-source
+# binary package, and its Sources index alone is ~12 MB per apt update.
+Types: deb
+URIs: $MIRROR
+Suites: sid
+Components: main
+Trusted: yes
 EOF


### PR DESCRIPTION
## What

Cherry-pick of the three commits from #186:

- 226b289: kernel 6.19 -> 7.1, fetch `linux-source` from sid (trixie-backports only carries 7.1.3). sid is added to apt sources pinned at priority 100, so no other package can ever resolve from it; only `linux-source` is explicitly requested via the new `KERNEL_APT_SUITE` env var. Drop the override once a >=7.1.5 backport lands in trixie-backports.
- 6c871d8 / ae4d90b: Debian snapshot `20260430T025253Z` -> `20260814T023117Z` so sid carries 7.1.8. Note this also pulls in ~3.5 months of trixie userspace updates across the images.

## Testing plan (L2 side, per kernel-update thread)

- [ ] CI image build (`l2/op-rbuilder+rproxy`, op-rbuilder v0.4.13), no cache
- [ ] dev3: deploy, verify `uname -a` = 7.1.8-mkosi-cloud, services healthy, blocks/flashblocks produced
- [ ] alphanet: deploy prod image, same checks

Already verified on `main` by @pablin-10: qemu boot of dev image shows `7.1.8-mkosi-cloud`.

## Notes

- 6.19 -> 7.1 is a major jump; our config snippets go through `olddefconfig`, which silently drops renamed/removed options (kernel `.config` diff worth a look during review.)
