### PR TITLE
Update nix flake and mkosi version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769170682,
-        "narHash": "sha256-oMmN1lVQU0F0W2k6OI3bgdzp2YOHWYUAw79qzDSjenU=",
+        "lastModified": 1787498568,
+        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c5296fdd05cfa2c187990dd909864da9658df755",
+        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -115,8 +115,8 @@
           src = pkgsForSystem.fetchFromGitHub {
             owner = "systemd";
             repo = "mkosi";
-            rev = "df51194bc2d890d4c267af644a1832d2d53339ac";
-            hash = "sha256-rGGzE9xIR8WvK07GBnaAmeLpmnM3Uy51wqyrmuHuWXo=";
+            rev = "f33cc45db3ddf0ed57594b58c9c161169d46e03c";
+            hash = "sha256-wjgucAQzjMy7GJiB+pbmYs3Fxvmg77gGGKIWlrJrarQ=";
           };
           # TODO: remove these patch hunks from upstream nixpkgs next time mkosi has a release
           # The latest mkosi doesn't need them
@@ -124,10 +124,15 @@
           postPatch = let
             fd = "${pkgs.patchutils}/bin/filterdiff";
           in ''
-            { ${fd} -x '*/run.py' --hunks=x2   ${builtins.elemAt old.patches 0}
+            { ${fd} -x '*/run.py' --hunks=x2,6 ${builtins.elemAt old.patches 0}
               ${fd} -i '*/run.py' --hunks=x1-2 ${builtins.elemAt old.patches 0}
               ${fd} --hunks=x1                 ${builtins.elemAt old.patches 1}
-            } | patch -p1
+            } | patch -p1 -F0
+
+            # From original nix package
+            substituteInPlace mkosi/__init__.py --replace-fail \
+              'systemd_tool_version(python_binary(context.config), ukify, sandbox=context.sandbox)' \
+              'systemd_tool_version(ukify, sandbox=context.sandbox)'
 
             # Don't add /usr/bin and /usr/sbin to the PATH, only use /nix
             sed -i -E '\#^\s+"/usr/(bin|sbin)",$#d' mkosi/run.py

--- a/mkosi.profiles/gcp/mkosi.postoutput
+++ b/mkosi.profiles/gcp/mkosi.postoutput
@@ -28,7 +28,7 @@ rm -f ${OUTPUTDIR}/${IMAGE_ID}_${IMAGE_VERSION}.raw
 # Dynamically size ESP partition and disk from EFI file
 MIB=$((1024 * 1024))
 EFI_BYTES=$(stat -c%s "${OUTPUTDIR}/${IMAGE_ID}_${IMAGE_VERSION}.efi")
-ESP_BYTES=$(( EFI_BYTES + 32 * MIB ))
+ESP_BYTES=$(( ((EFI_BYTES + MIB - 1) / MIB + 32) * MIB ))
 DISK_GIB=$(numfmt --to-unit=1Gi --round=up $(( ESP_BYTES + MIB ))) # + 1MiB GPT overhead
 
 REPART_TMPDIR=$(mktemp -d)


### PR DESCRIPTION
I was running into an HTTP 403 issue because crates.io was flagging nixpkgs fetchurl as spam. This was fixed upstream in nixpkgs so i updated our nix flake along with the mkosi version. confirmed that there were no regressions in the final initrd