### PR TITLE
Document GCP provenance check on Flashbox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ ifndef IMAGE
 	$(error IMAGE is not set. Please specify IMAGE=<image> when running make build or make build-dev)
 endif
 
-.PHONY: all build build-dev setup measure measure-portable clean check-module
+.PHONY: all build build-dev setup measure measure-portable measure-portable-gcp clean check-module
 
 # Default target
 all: build
@@ -55,6 +55,10 @@ measure: ## Export TDX measurements for the built EFI file
 measure-portable: ## Export portable measurements for the built EFI file
 	@$(WRAPPER) bash -c 'attest measure portable "$$1" > build/portable_measurements.json' _ "$(FILE)"
 	echo "Portable measurements exported to build/portable_measurements.json"
+
+measure-portable-gcp: measure-portable ## Export a portable GCP-only attestation policy for the built EFI file
+	@$(WRAPPER) bash -c 'jq -e "[{attestation_type: \"gcp-tdx\", dcap_image_hashes: .dcap}]" build/portable_measurements.json > build/measurements-gcp.json'
+	echo "GCP attestation policy exported to build/measurements-gcp.json"
 
 measure-gcp: ## Export TDX measurements for GCP
 	@$(WRAPPER) dstack-mr -uki $(FILE) > build/gcp_measurements.json

--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ make measure-portable
 
 This will create a file `build/portable_measurements.json` which can be used for [portable measurement policies](https://github.com/flashbots/attested-tls/tree/main/crates/attestation#portable-measurement-policies).
 
+To require GCP provenance as well as the image measurements:
+
+```bash
+make measure-portable-gcp
+```
+
+This also generates `build/portable_measurements.json` and writes a policy with `attestation_type: "gcp-tdx"` to `build/measurements-gcp.json`, ready to pass to `attested-tls-proxy --measurements-file`. Both portable measurement targets accept `FILE=/path/to/image.efi` (default: `build/latest.efi`).
+
 ### Running Images
 
 **Add yourself to the kvm group** (to run QEMU without sudo):

--- a/modules/flashbox/flashbox-l1/readme.md
+++ b/modules/flashbox/flashbox-l1/readme.md
@@ -201,9 +201,17 @@ cd flashbots-images
 make measure-portable
 ```
 
-This will write the OS image hashes to the file `./build/portable_measurements.json`.
+This writes the OS image hashes to `./build/portable_measurements.json`.
 
-Check that the contents of this file is identical to the same file in the [release assets of the flashbots-image release](https://github.com/flashbots/flashbots-images/releases) you are building.
+If you are deploying on GCP, use this command instead:
+
+```bash
+make measure-portable-gcp
+```
+
+This generates the same `./build/portable_measurements.json` and also writes a GCP-only attestation policy to `./build/measurements-gcp.json`.
+
+Check that the contents of `portable_measurements.json` are identical to the same file in the [release assets of the flashbots-image release](https://github.com/flashbots/flashbots-images/releases) you are building.
 
 > Note: at the time of the writing, compiling flashbox-l1 image is not reproducible if building under ARM mac with Rosetta. Please use x86_64 Linux for now.
 
@@ -211,26 +219,30 @@ Check that the contents of this file is identical to the same file in the [relea
 
 Flashbots uses a custom [attested TLS protocol](https://github.com/flashbots/attested-tls-proxy/blob/main/attested-tls/README.md) to retrieve a TDX DCAP attestation and compare it with expected measurement values built from the locally supplied OS image hashes.
 
+For GCP deployments, if the clients measurement policy specifies `"attestation_type": "gcp-tdx"`, GCP provenance verification will be used in addition to DCAP quote and image measurement verification. The verifier checks the platform identifier (PPID) from the quote's PCK certificate against Google's confidential host registry. The `make measure-portable-gcp` command above specifies this in the policy to enable these checks.
+
 After deploying to GCP, and uploading SSH public key via a POST request:
 
 ```bash
 # download remote attestation tool
 git clone https://github.com/flashbots/attested-tls-proxy.git
+cp build/measurements-gcp.json attested-tls-proxy/measurements.json
 cd attested-tls-proxy
 
 # This will run the client proxy that is listening on port 8080
 # and use the server reverse proxy on the deployed image as a target,
 # marshalling the measurements.json for validation of the attestation.
-cargo run -- client \
+cargo run --locked -- client \
   --listen-addr 127.0.0.1:8080 \
   --allow-self-signed \
   --measurements-file ./measurements.json \
   --log-debug \
   <VM IP>:8745
 
-# If attestation can be successfully validated against the given image hashes
+# If GCP provenance and attestation validate against the given image hashes,
 # you should see the measurement values displayed as in the example output below.
 
+# In a second terminal, while the client proxy remains running:
 # Bind the attested host keys to known_hosts.
 # This ensures the ssh server the searcher connects to is the one running on the
 # attested machine. The attested :8745 channel and the host (dropbear) control-plane


### PR DESCRIPTION
GCP provenance checks are implemented in the release of attested-tls-proxy now used by Flashbox.

But the documentation doesn't explain how to specify that you expect a GCP deployment in order to enforce this check.

This PR adds that documentation and a specific Makefile command for convenience.

Tested in https://github.com/flashbots/devops/actions/runs/34217380041 - see related PR in devops repo: https://github.com/flashbots/devops/pull/2762