### PR TITLE
Allow DNS resolution of rpc.buildernet.org

### DIFF
--- a/modules/flashbox/common/mkosi.extra/usr/bin/toggle
+++ b/modules/flashbox/common/mkosi.extra/usr/bin/toggle
@@ -109,19 +109,23 @@ check_delay() {
 # Kill established connections via conntrack
 ###############################################################################
 kill_production_connections() {
+    echo "Killing leftover production flows:"
     if [ ${#PRODUCTION_ENDPOINTS[@]} -eq 0 ]; then
-        echo "Killing leftover production flows:"
         echo "     - No production endpoints configured"
-        return
+    else
+        for endpoint in "${PRODUCTION_ENDPOINTS[@]}"; do
+            local ip="${endpoint%%:*}"
+            local name="${endpoint#*:}"
+            echo "     - $name ($ip)"
+            $CONNTRACK -D -d "$ip" 2>/dev/null || true
+        done
     fi
 
-    echo "Killing leftover production flows:"
-    for endpoint in "${PRODUCTION_ENDPOINTS[@]}"; do
-        local ip="${endpoint%%:*}"
-        local name="${endpoint#*:}"
-        echo "     - $name ($ip)"
-        $CONNTRACK -D -d "$ip" 2>/dev/null || true
-    done
+    # Dynamic endpoint cleanup must run after the production selector has been
+    # removed. Images can provide this hook to avoid racing a refresh.
+    if declare -F kill_image_production_connections >/dev/null; then
+        kill_image_production_connections
+    fi
 }
 
 kill_maintenance_connections() {
@@ -249,6 +253,13 @@ move_to_production() {
     # Check the searcher-container-netns iptables rules are active first:
     if ! check_searcher_namespace_rules; then
         echo "Error: Required searcher-container-netns iptables rules not active!"
+        return 1
+    fi
+
+    # Images may define additional fail-closed checks in toggle-config.
+    if declare -F check_image_production_prerequisites >/dev/null \
+       && ! check_image_production_prerequisites; then
+        echo "Error: Image-specific production prerequisites are not satisfied!"
         return 1
     fi
 

--- a/modules/flashbox/flashbox-l1/mkosi.conf
+++ b/modules/flashbox/flashbox-l1/mkosi.conf
@@ -16,3 +16,7 @@ BuildPackages=build-essential
               libsnappy-dev
               libpq-dev
               libssl-dev
+
+Packages=dnsdist
+         bind9-dnsutils
+         nftables

--- a/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/firewall-config
+++ b/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/firewall-config
@@ -36,14 +36,30 @@ FLASHBOTS_TX_STREAM_2="3.149.14.12"
 # toggle-config PRODUCTION_ENDPOINTS). Consequently BuilderNet bundle submission
 # works only in production mode, unlike the always-on Flashbots bundles.
 #
-# Production mode has no DNS, so these are addressed by IP; the hostnames searchers
-# connect to (for TLS) are mapped statically in searcher-container-after-init.
+# The static addresses below are retained only as maintenance-mode deny rules and
+# conntrack cleanup coverage for addresses used by older images. Production access
+# is granted exclusively through the DNSSEC-refreshed buildernet_v4 nftables set.
 BUILDERNET_FB_OM_USE1_00="200.225.47.181"  # fb-om-use1-00  (US east)
 BUILDERNET_FB_OM_USE1_01="200.225.47.183"  # fb-om-use1-01  (US east)
 BUILDERNET_FB_OM_EUW1_00="198.203.202.53"  # fb-om-euw1-00  (EU west)
 BUILDERNET_FB_OM_EUW1_01="198.203.202.55"  # fb-om-euw1-01  (EU west)
 BUILDERNET_FB_OM_AP1_00="198.203.203.37"   # fb-om-ap1-00   (AP northeast)
 BUILDERNET_FB_GCP_ANE1_00="34.104.157.101" # fb-gcp-ane1-00 (AP northeast)
+
+# Searcher-only DNS proxy. dnsdist talks to Cloudflare using authenticated DoT;
+# the searcher itself cannot use this destination rule because pasta runs as the
+# searcher user while the rule is restricted to the _dnsdist uid.
+CLOUDFLARE_DNS="1.1.1.1"
+CLOUDFLARE_DNS_UID="_dnsdist"
+
+# iptables-nft and nft share the ip/filter table. Preserve this set across
+# firewall-service restarts so a failed refresh retains the last-known-good
+# addresses. The kernel set starts empty after reboot; the refresh service
+# restores its validated persistent copy before attempting a live refresh.
+BUILDERNET_NFT_SET="buildernet_v4"
+if ! /usr/sbin/nft list set ip filter "$BUILDERNET_NFT_SET" >/dev/null 2>&1; then
+    /usr/sbin/nft add set ip filter "$BUILDERNET_NFT_SET" '{ type ipv4_addr; }'
+fi
 
 # Prometheus metrics proxy
 PROMETHEUS_PROXY_IP="10.88.0.100"
@@ -87,6 +103,21 @@ accept_dst_ip_port $CHAIN_ALWAYS_OUT tcp $FLASHBOTS_BUNDLE_1,$FLASHBOTS_BUNDLE_2
 # Prometheus metrics proxy (searcher netns has a DROP on this IP — see init-container.sh)
 accept_dst_ip_port $CHAIN_ALWAYS_OUT tcp $PROMETHEUS_PROXY_IP $HTTPS_PORT "Prometheus metrics proxy"
 
+# The only production-capable path to a recursive DNS service. This is DoT, not
+# plain DNS, and only the unprivileged exact-name proxy may open the connection.
+iptables -A "$CHAIN_ALWAYS_OUT" -p tcp -d "$CLOUDFLARE_DNS" --dport "$DNS_OVER_TLS_PORT" \
+    -m owner --uid-owner "$CLOUDFLARE_DNS_UID" \
+    -m conntrack --ctstate NEW -j ACCEPT \
+    -m comment --comment "BuilderNet DNS proxy to Cloudflare DoT"
+
+# Do not let a compromised DNS parser pivot to host loopback services, the
+# dynamically allowed HTTPS addresses, or maintenance-mode general egress.
+# Replies to searcher queries are ESTABLISHED and accepted before this chain.
+iptables -A "$CHAIN_ALWAYS_OUT" \
+    -m owner --uid-owner "$CLOUDFLARE_DNS_UID" \
+    -m conntrack --ctstate NEW -j DROP \
+    -m comment --comment "Confine BuilderNet DNS proxy egress"
+
 ###########################################################################
 # (3) MAINTENANCE_IN: Inbound rules for Maintenance Mode
 ###########################################################################
@@ -106,6 +137,13 @@ drop_dst_ip $CHAIN_MAINTENANCE_OUT $FLASHBOTS_TX_STREAM_1,$FLASHBOTS_TX_STREAM_2
 
 # Block BuilderNet endpoints during maintenance. 
 drop_dst_ip $CHAIN_MAINTENANCE_OUT $BUILDERNET_FB_OM_USE1_00,$BUILDERNET_FB_OM_USE1_01,$BUILDERNET_FB_OM_EUW1_00,$BUILDERNET_FB_OM_EUW1_01,$BUILDERNET_FB_OM_AP1_00,$BUILDERNET_FB_GCP_ANE1_00 "BuilderNet (DROP before accept-all rules)"
+
+# Also block every current dynamically resolved address before maintenance's
+# general HTTPS allow rule. Established connections are deleted on mode changes
+# and whenever the resolver removes an address from the set.
+/usr/sbin/nft add rule ip filter "$CHAIN_MAINTENANCE_OUT" \
+    ip daddr @"$BUILDERNET_NFT_SET" drop \
+    comment '"BuilderNet dynamic endpoints"'
 
 accept_dst_port $CHAIN_MAINTENANCE_OUT udp $DNS_PORT "DNS (UDP)"
 accept_dst_port $CHAIN_MAINTENANCE_OUT tcp $DNS_PORT "DNS (TCP)"
@@ -129,5 +167,9 @@ accept_dst_port $CHAIN_MAINTENANCE_OUT udp $EL_P2P_PORT "EL P2P (UDP)"
 
 accept_dst_ip_port $CHAIN_PRODUCTION_OUT tcp $FLASHBOTS_TX_STREAM_1,$FLASHBOTS_TX_STREAM_2 $HTTPS_PORT "Flashbots Protect tx stream"
 
-# BuilderNet tx stream (path /bob) + bundle submission (bare path), same HTTPS endpoint
-accept_dst_ip_port $CHAIN_PRODUCTION_OUT tcp $BUILDERNET_FB_OM_USE1_00,$BUILDERNET_FB_OM_USE1_01,$BUILDERNET_FB_OM_EUW1_00,$BUILDERNET_FB_OM_EUW1_01,$BUILDERNET_FB_OM_AP1_00,$BUILDERNET_FB_GCP_ANE1_00 $HTTPS_PORT "BuilderNet tx stream + bundle submission"
+# BuilderNet tx stream (path /bob) + bundle submission (bare path), same HTTPS
+# endpoint. Only DNSSEC-authenticated A records in the current LKG set match.
+/usr/sbin/nft add rule ip filter "$CHAIN_PRODUCTION_OUT" \
+    ip daddr @"$BUILDERNET_NFT_SET" tcp dport "$HTTPS_PORT" \
+    ct state new accept \
+    comment '"BuilderNet DNSSEC endpoints"'

--- a/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/searcher-container-after-init
+++ b/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/searcher-container-after-init
@@ -1,22 +1,11 @@
 # This script is sourced from init-container.sh and contains image-specific stuff
 # See also: bob-common/mkosi.extra/usr/bin/init-container.sh
 
-echo "Injecting static hosts into searcher container..."
+echo "Injecting static Flashbots hosts into searcher container..."
 exec_in_container '
     cat <<EOF >> /etc/hosts
 3.149.14.12   tx.tee-searcher.flashbots.net
 3.136.107.142 tx.tee-searcher.flashbots.net
 18.221.59.61  backruns.tee-searcher.flashbots.net
 3.15.88.156   backruns.tee-searcher.flashbots.net
-
-# BuilderNet. Searchers connect by hostname so TLS validates (production mode has
-# no DNS). US nodes are listed first for latency. Mapping all IPs to
-# rpc.buildernet.org here means failover is dial-level (next IP on connect
-# failure), not health-aware like the BuilderNet load balancer.
-200.225.47.181 fb-om-use1-00.nodes.buildernet.org direct-us.buildernet.org rpc.buildernet.org
-200.225.47.183 fb-om-use1-01.nodes.buildernet.org direct-us.buildernet.org rpc.buildernet.org
-198.203.202.53  fb-om-euw1-00.nodes.buildernet.org direct-eu.buildernet.org rpc.buildernet.org
-198.203.202.55  fb-om-euw1-01.nodes.buildernet.org direct-eu.buildernet.org rpc.buildernet.org
-198.203.203.37  fb-om-ap1-00.nodes.buildernet.org direct-ap.buildernet.org rpc.buildernet.org
-34.104.157.101 fb-gcp-ane1-00.nodes.buildernet.org direct-ap.buildernet.org rpc.buildernet.org
 EOF'

--- a/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/searcher-container-before-init
+++ b/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/searcher-container-before-init
@@ -5,6 +5,8 @@ ENGINE_API_PORT=8551
 EL_P2P_PORT=30303
 
 BOB_SEARCHER_EXTRA_PODMAN_FLAGS="\
+    --network pasta:--no-map-gw,--dns-forward,169.254.2.3,--dns-host,127.0.0.55 \
+    --dns 169.254.2.3 \
     -p ${ENGINE_API_PORT}:${ENGINE_API_PORT} \
     -p ${EL_P2P_PORT}:${EL_P2P_PORT} \
     -p ${EL_P2P_PORT}:${EL_P2P_PORT}/udp \

--- a/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/toggle-config
+++ b/modules/flashbox/flashbox-l1/mkosi.extra/etc/bob/toggle-config
@@ -20,6 +20,8 @@ PRODUCTION_ENDPOINTS=(
     "34.104.157.101:BuilderNet fb-gcp-ane1-00"
 )
 
+BUILDERNET_ADDRESS_STATE="/persistent/buildernet-dns/addresses"
+
 # Maintenance ports (format: "protocol:port:description")
 MAINTENANCE_ENDPOINTS=(
     "tcp:10022:SSH data port"
@@ -31,3 +33,57 @@ MAINTENANCE_ENDPOINTS=(
     "tcp:30303:EL P2P"
     "udp:30303:EL P2P"
 )
+
+kill_image_production_connections() {
+    # The production selector has already been removed, so no new HTTPS flow
+    # can be admitted. Deleting all existing TCP/443 state also covers an
+    # address removed by a refresh that was interrupted before its own cleanup.
+    echo "     - All production HTTPS flows (including dynamic BuilderNet endpoints)"
+    /usr/sbin/conntrack -D -p tcp --dport 443 2>/dev/null || true
+}
+
+check_image_production_prerequisites() {
+    local state_addresses nft_addresses
+
+    if ! systemctl is-active --quiet dnsdist.service; then
+        echo "ERROR: BuilderNet exact-name DNS proxy is not active"
+        return 1
+    fi
+    if [[ ! -s "$BUILDERNET_ADDRESS_STATE" ]]; then
+        echo "ERROR: No last-known-good BuilderNet DNS address set is available"
+        return 1
+    fi
+
+    if ! /usr/sbin/nft list set ip filter buildernet_v4 >/dev/null 2>&1; then
+        echo "ERROR: BuilderNet nftables set is missing"
+        return 1
+    fi
+    state_addresses=$(sort -u "$BUILDERNET_ADDRESS_STATE")
+    nft_addresses=$(
+        /usr/sbin/nft -j list set ip filter buildernet_v4 |
+            /usr/bin/jq -r '
+                .nftables[]
+                | .set?
+                | select(.family == "ip" and .table == "filter" and .name == "buildernet_v4")
+                | .elem[]?
+            ' |
+            sort -u
+    )
+    if [[ "$state_addresses" != "$nft_addresses" ]]; then
+        echo "ERROR: BuilderNet address state and nftables set differ"
+        return 1
+    fi
+
+    # example.com has A records, so resolving it here would prove that the
+    # searcher bypassed the exact-name policy. Upstream availability is not a
+    # prerequisite: the selected LKG policy intentionally survives DNS outages.
+    if su -s /bin/sh searcher -c \
+        "podman exec searcher-container getent ahostsv4 example.com" \
+        >/dev/null 2>&1; then
+        echo "ERROR: Searcher DNS resolved a non-allowlisted name"
+        return 1
+    fi
+
+    echo "OK: BuilderNet exact-name DNS proxy and last-known-good address set are active"
+    return 0
+}

--- a/modules/flashbox/flashbox-l1/mkosi.extra/etc/dnsdist/dnsdist.conf
+++ b/modules/flashbox/flashbox-l1/mkosi.extra/etc/dnsdist/dnsdist.conf
@@ -1,0 +1,89 @@
+-- The searcher reaches this listener through pasta's dedicated DNS forwarder.
+-- Keep the listener on its own loopback address so it cannot collide with
+-- systemd-resolved on 127.0.0.53 and its proxy listener on 127.0.0.54.
+setLocal("127.0.0.55:53")
+setACL({"127.0.0.1/32"})
+
+-- Disable dnsdist's own security-status DNS polling. The only upstream queries
+-- from this process must be fixed health checks or allowlisted searcher queries.
+setSecurityPollSuffix("")
+
+-- Cloudflare's recursive resolver validates DNSSEC. DoT authenticates the
+-- resolver and prevents an on-path party from forging the AD bit or response.
+newServer({
+  address="1.1.1.1:853",
+  tls="openssl",
+  subjectName="cloudflare-dns.com",
+  validateCertificates=true,
+  caStore="/etc/ssl/certs/ca-certificates.crt",
+  pool="buildernet",
+  checkName="rpc.buildernet.org.",
+  checkType="A",
+  mustResolve=true
+})
+
+local buildernetNames = newDNSNameSet()
+buildernetNames:add(newDNSName("rpc.buildernet.org."))
+buildernetNames:add(newDNSName("direct-ap.buildernet.org."))
+buildernetNames:add(newDNSName("direct-eu.buildernet.org."))
+buildernetNames:add(newDNSName("direct-us.buildernet.org."))
+
+local exactBuildernetName = QNameSetRule(buildernetNames)
+
+-- pasta makes every container query appear from one loopback client. Apply a
+-- global ceiling before any forwarding to keep an attacker from turning the
+-- four allowed names into an unbounded query flood.
+addAction(AllRule(), QPSAction(100))
+
+-- An OPT record is useful for modern stub resolvers, but its option payload is
+-- an otherwise opaque data carrier. Permit only an empty OPT record. Reject
+-- trailing bytes for the same reason.
+local noEDNSOptions = LuaRule(function(dq)
+  local options = dq:getEDNSOptions()
+  return options == nil or next(options) == nil
+end)
+
+local validQuerySections = AndRule({
+  RecordsCountRule(DNSSection.Question, 1, 1),
+  RecordsCountRule(DNSSection.Answer, 0, 0),
+  RecordsCountRule(DNSSection.Authority, 0, 0),
+  NotRule(TrailingDataRule()),
+  noEDNSOptions,
+  OrRule({
+    RecordsCountRule(DNSSection.Additional, 0, 0),
+    AndRule({
+      RecordsCountRule(DNSSection.Additional, 1, 1),
+      RecordsTypeCountRule(DNSSection.Additional, DNSQType.OPT, 1, 1)
+    })
+  })
+})
+
+-- Only ordinary A/IN queries for the four exact names reach Cloudflare.
+-- In particular, QNameSetRule is an exact match: prefixes and subdomains do
+-- not match. Non-question sections must be empty, except for one conventional
+-- EDNS OPT record so modern resolvers continue to work.
+local allowedAQuery = AndRule({
+  exactBuildernetName,
+  QTypeRule(DNSQType.A),
+  QClassRule(DNSClass.IN),
+  OpcodeRule(DNSOpcode.Query),
+  validQuerySections
+})
+addAction(allowedAQuery, PoolAction("buildernet"))
+
+-- libc commonly asks for AAAA before A. Return authenticated-name-compatible
+-- NODATA locally without forwarding anything upstream; this image has IPv6
+-- disabled in the kernel.
+local allowedAAAAQuery = AndRule({
+  exactBuildernetName,
+  QTypeRule(DNSQType.AAAA),
+  QClassRule(DNSClass.IN),
+  OpcodeRule(DNSOpcode.Query),
+  validQuerySections
+})
+-- dnsdist 1.9 in Debian 13 does not expose a named NOERROR constant, so use
+-- the protocol value directly.
+addAction(allowedAAAAQuery, RCodeAction(0))
+
+-- No other QNAME, QTYPE, class, opcode, or packet shape is forwarded.
+addAction(AllRule(), RCodeAction(DNSRCode.NXDOMAIN))

--- a/modules/flashbox/flashbox-l1/mkosi.extra/etc/systemd/system/buildernet-dns-refresh.service
+++ b/modules/flashbox/flashbox-l1/mkosi.extra/etc/systemd/system/buildernet-dns-refresh.service
@@ -1,0 +1,35 @@
+[Unit]
+Description=Refresh DNSSEC-authenticated BuilderNet firewall addresses
+After=network-online.target time-sync.target dnsdist.service searcher-firewall.service persistent-mount.service
+Wants=network-online.target
+Requires=dnsdist.service searcher-firewall.service persistent-mount.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/refresh-buildernet-dns
+RuntimeDirectory=buildernet-dns-refresh
+RuntimeDirectoryMode=0700
+UMask=0077
+
+# This fixed-input process is the only component allowed to mutate the host
+# firewall set. The attacker-facing DNS parser has no CAP_NET_ADMIN.
+CapabilityBoundingSet=CAP_NET_ADMIN
+AmbientCapabilities=CAP_NET_ADMIN
+NoNewPrivileges=yes
+PrivateDevices=yes
+PrivateTmp=yes
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectProc=invisible
+ProtectSystem=strict
+ReadWritePaths=/persistent/buildernet-dns
+RestrictAddressFamilies=AF_INET AF_NETLINK AF_UNIX
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+SystemCallArchitectures=native

--- a/modules/flashbox/flashbox-l1/mkosi.extra/etc/systemd/system/buildernet-dns-refresh.timer
+++ b/modules/flashbox/flashbox-l1/mkosi.extra/etc/systemd/system/buildernet-dns-refresh.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Periodically refresh BuilderNet firewall addresses
+
+[Timer]
+OnBootSec=5s
+OnUnitInactiveSec=60s
+RandomizedDelaySec=5s
+AccuracySec=1s
+Unit=buildernet-dns-refresh.service
+
+[Install]
+WantedBy=minimal.target

--- a/modules/flashbox/flashbox-l1/mkosi.extra/etc/systemd/system/persistent-mount.service.d/buildernet-dns.conf
+++ b/modules/flashbox/flashbox-l1/mkosi.extra/etc/systemd/system/persistent-mount.service.d/buildernet-dns.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPost=/usr/bin/install -d -o root -g root -m 0700 /persistent/buildernet-dns

--- a/modules/flashbox/flashbox-l1/mkosi.extra/etc/systemd/system/searcher-container.service.d/buildernet-dns.conf
+++ b/modules/flashbox/flashbox-l1/mkosi.extra/etc/systemd/system/searcher-container.service.d/buildernet-dns.conf
@@ -1,0 +1,3 @@
+[Unit]
+After=dnsdist.service
+Requires=dnsdist.service

--- a/modules/flashbox/flashbox-l1/mkosi.extra/usr/bin/refresh-buildernet-dns
+++ b/modules/flashbox/flashbox-l1/mkosi.extra/usr/bin/refresh-buildernet-dns
@@ -1,0 +1,238 @@
+#!/bin/bash
+set -euo pipefail
+
+readonly DNS_SERVER="${BUILDERNET_DNS_SERVER:-127.0.0.55}"
+readonly DNS_PORT="${BUILDERNET_DNS_PORT:-53}"
+readonly NFT_FAMILY="ip"
+readonly NFT_TABLE="filter"
+readonly NFT_SET="buildernet_v4"
+readonly STATE_DIR="${STATE_DIRECTORY:-/persistent/buildernet-dns}"
+readonly STATE_FILE="$STATE_DIR/addresses"
+readonly RUNTIME_DIR="${RUNTIME_DIRECTORY:-/run/buildernet-dns-refresh}"
+
+readonly -a BUILDERNET_NAMES=(
+    "rpc.buildernet.org"
+    "direct-ap.buildernet.org"
+    "direct-eu.buildernet.org"
+    "direct-us.buildernet.org"
+)
+
+die() {
+    echo "ERROR: $*; retaining the last-known-good BuilderNet address set" >&2
+    exit 1
+}
+
+is_public_ipv4() {
+    local ip="$1"
+    local a b c d
+
+    if [[ ! "$ip" =~ ^(0|[1-9][0-9]{0,2})\.(0|[1-9][0-9]{0,2})\.(0|[1-9][0-9]{0,2})\.(0|[1-9][0-9]{0,2})$ ]]; then
+        return 1
+    fi
+
+    IFS=. read -r a b c d <<<"$ip"
+    if ((a > 255 || b > 255 || c > 255 || d > 255)); then
+        return 1
+    fi
+
+    # Reject non-global and special-use ranges. The BuilderNet load balancers
+    # must never turn the production HTTPS rule into access to local services,
+    # cloud metadata, private networks, multicast, or documentation ranges.
+    if ((a == 0 || a == 10 || a == 127 || a >= 224)); then
+        return 1
+    fi
+    if ((a == 100 && b >= 64 && b <= 127)); then
+        return 1
+    fi
+    if ((a == 169 && b == 254)); then
+        return 1
+    fi
+    if ((a == 172 && b >= 16 && b <= 31)); then
+        return 1
+    fi
+    if ((a == 192 && b == 0 && (c == 0 || c == 2))); then
+        return 1
+    fi
+    if ((a == 192 && b == 168)); then
+        return 1
+    fi
+    if ((a == 192 && b == 88 && c == 99)); then
+        return 1
+    fi
+    if ((a == 198 && (b == 18 || b == 19))); then
+        return 1
+    fi
+    if ((a == 198 && b == 51 && c == 100)); then
+        return 1
+    fi
+    if ((a == 203 && b == 0 && c == 113)); then
+        return 1
+    fi
+
+    return 0
+}
+
+resolve_exact_a() {
+    local name="$1"
+    local attempt reply addresses
+
+    # A DNSSEC key/signature rollout can briefly leave recursive-cache shards
+    # without an authenticated answer. Retry before falling back to the LKG set.
+    for attempt in 1 2 3 4 5; do
+        addresses=""
+        if reply=$(/usr/bin/dig \
+            @"$DNS_SERVER" -p "$DNS_PORT" "$name" A \
+            +tcp +dnssec +adflag +nocookie +time=5 +tries=1 \
+            +noall +comments +answer) &&
+            grep -q "status: NOERROR" <<<"$reply" &&
+            grep -Eq '^;; flags:.*[[:space:]]ad[;[:space:]]' <<<"$reply" &&
+            addresses=$(awk -v expected="${name}." '
+                BEGIN { count = 0; signatures = 0; invalid = 0 }
+                /^;/ || NF == 0 { next }
+                {
+                    if (tolower($1) != tolower(expected) || toupper($3) != "IN") {
+                        invalid = 1
+                        next
+                    }
+                    if (toupper($4) == "A") {
+                        print $5
+                        count++
+                    } else if (toupper($4) == "RRSIG" && toupper($5) == "A") {
+                        signatures++
+                    } else {
+                        invalid = 1
+                    }
+                }
+                END {
+                    if (invalid || count == 0 || signatures == 0) exit 1
+                }
+            ' <<<"$reply"); then
+            printf '%s\n' "$addresses"
+            return 0
+        fi
+
+        echo "WARNING: attempt $attempt did not return a direct, DNSSEC-authenticated A answer for $name" >&2
+        if ((attempt < 5)); then
+            sleep 1
+        fi
+    done
+
+    # Accept only direct A records owned by the exact requested name. A CNAME
+    # (especially one leaving buildernet.org) is deliberately not followed.
+    die "no valid DNS answer for $name after 5 attempts"
+}
+
+validate_address_file() {
+    local file="$1"
+    local ip count
+
+    [[ -s "$file" ]] || return 1
+    count=$(wc -l <"$file")
+    ((count <= 64)) || return 1
+
+    while IFS= read -r ip; do
+        [[ -n "$ip" ]] && is_public_ipv4 "$ip" || return 1
+    done <"$file"
+}
+
+read_current_addresses() {
+    /usr/sbin/nft -j list set "$NFT_FAMILY" "$NFT_TABLE" "$NFT_SET" |
+        /usr/bin/jq -r '
+            .nftables[]
+            | .set?
+            | select(.family == "ip" and .table == "filter" and .name == "buildernet_v4")
+            | .elem[]?
+        ' |
+        sort -u
+}
+
+replace_nft_set() {
+    local addresses_file="$1"
+    local transaction_file="$2"
+    local element_list
+
+    element_list=$(paste -sd, "$addresses_file")
+    {
+        printf 'flush set %s %s %s\n' "$NFT_FAMILY" "$NFT_TABLE" "$NFT_SET"
+        printf 'add element %s %s %s { %s }\n' \
+            "$NFT_FAMILY" "$NFT_TABLE" "$NFT_SET" "$element_list"
+    } >"$transaction_file"
+
+    # nft applies the whole file as one netlink transaction. A failed batch
+    # leaves the live set unchanged.
+    /usr/sbin/nft -f "$transaction_file"
+}
+
+main() {
+    local name ip
+    local raw_file candidate_file transaction_file old_live_file lkg_file state_tmp
+
+    install -d -m 0700 "$STATE_DIR" "$RUNTIME_DIR"
+    exec 9>"$RUNTIME_DIR/refresh.lock"
+    if ! flock -n 9; then
+        echo "BuilderNet DNS refresh is already running"
+        return 0
+    fi
+
+    raw_file=$(mktemp)
+    candidate_file=$(mktemp)
+    transaction_file=$(mktemp)
+    old_live_file=$(mktemp)
+    lkg_file=$(mktemp)
+    trap 'rm -f "$raw_file" "$candidate_file" "$transaction_file" "$old_live_file" "$lkg_file"' EXIT
+
+    # systemd.volatile=overlay discards root-filesystem changes on reboot, so
+    # the LKG state is kept on /persistent. Restore it only when the live set is
+    # empty. A corrupt state file fails closed and is never loaded.
+    read_current_addresses >"$old_live_file" || die "could not read the nftables set"
+    if [[ ! -s "$old_live_file" && -r "$STATE_FILE" ]]; then
+        sort -u "$STATE_FILE" >"$lkg_file"
+        if validate_address_file "$lkg_file"; then
+            replace_nft_set "$lkg_file" "$transaction_file" ||
+                die "could not restore the last-known-good nftables set"
+            echo "Restored last-known-good BuilderNet address set"
+        else
+            echo "WARNING: Ignoring invalid last-known-good BuilderNet address state" >&2
+        fi
+    fi
+
+    for name in "${BUILDERNET_NAMES[@]}"; do
+        resolve_exact_a "$name" >>"$raw_file"
+    done
+
+    while IFS= read -r ip; do
+        is_public_ipv4 "$ip" || die "DNS returned prohibited IPv4 address '$ip'"
+    done <"$raw_file"
+
+    sort -u "$raw_file" >"$candidate_file"
+    validate_address_file "$candidate_file" || die "DNS returned an invalid address set"
+
+    # Read the live set immediately before replacement. This, rather than the
+    # state file, is authoritative for cleanup after an interrupted prior run.
+    read_current_addresses >"$old_live_file" || die "could not read the nftables set"
+
+    # Prepare state bookkeeping before touching the live firewall. The final
+    # rename is same-filesystem and atomic.
+    state_tmp="$STATE_FILE.new"
+    install -m 0600 "$candidate_file" "$state_tmp"
+
+    replace_nft_set "$candidate_file" "$transaction_file" || {
+        rm -f "$state_tmp"
+        die "could not atomically replace the nftables set"
+    }
+
+    # The host firewall accepts ESTABLISHED traffic before mode-specific rules.
+    # Tear down flows immediately after removing addresses from the set, before
+    # doing any state-file bookkeeping that could fail independently.
+    comm -23 "$old_live_file" "$candidate_file" | while IFS= read -r ip; do
+        [[ -n "$ip" ]] || continue
+        echo "Removing established connections to retired BuilderNet address $ip"
+        /usr/sbin/conntrack -D -d "$ip" 2>/dev/null || true
+    done
+
+    mv -f "$state_tmp" "$STATE_FILE"
+
+    echo "BuilderNet address set refreshed: $(tr '\n' ' ' <"$candidate_file")"
+}
+
+main "$@"

--- a/modules/flashbox/flashbox-l1/mkosi.postinst
+++ b/modules/flashbox/flashbox-l1/mkosi.postinst
@@ -8,3 +8,6 @@ mkosi-chroot groupadd -r eth
 mkosi-chroot useradd -r -s /bin/false -G eth lighthouse
 
 mkosi-chroot systemctl add-wants minimal.target lighthouse.service
+mkosi-chroot systemctl add-wants minimal.target \
+    dnsdist.service \
+    buildernet-dns-refresh.timer

--- a/modules/flashbox/flashbox-l1/readme.md
+++ b/modules/flashbox/flashbox-l1/readme.md
@@ -59,7 +59,9 @@ Firewall Rules
 ------------------------
 <img alt="tee-searcher-networking" src="https://github.com/user-attachments/assets/8dd72ece-44de-4907-9d2d-1dd32b7c1468" />
 
-**IMPORTANT: Searchers, you will not have DNS access during production mode!**
+**IMPORTANT: During production mode, DNS returns A records only for exactly
+`rpc.buildernet.org` and `direct-{ap,eu,us}.buildernet.org`. AAAA queries for
+those names receive NODATA; all other queries receive NXDOMAIN locally.**
 
 **<u>Host Network Namespace iptables</u>**
 
@@ -74,7 +76,8 @@ Firewall Rules
 | 443   | Output **IP WHITELISTED** | Flashbots Protect Tx Stream     | Podman               | TCP       | ENABLED         | DISABLED         |
 | 443   | Output **IP WHITELISTED** | BuilderNet State Diff Stream + Bundle RPC | BuilderNet RPC | TCP   | ENABLED         | DISABLED         |
 | 443   | Output **IP WHITELISTED** | Flashbots Bundle RPC            | Flashbots Bundle RPC | TCP       | ENABLED         | ENABLED          |
-| 53    | Output                    | DNS                             | DNS                  | TCP + UDP | DISABLED        | ENABLED          |
+| 53    | Output **NAME WHITELISTED** | BuilderNet DNS                | Local DNS proxy      | TCP + UDP | ENABLED         | ENABLED          |
+| 53/853 | Output                   | Direct DNS / DNS-over-TLS       | External DNS         | TCP + UDP | DISABLED        | ENABLED          |
 | 80    | Output                    | HTTP                            | HTTP                 | TCP       | DISABLED        | ENABLED          |
 | 443   | Output                    | HTTPS                           | HTTPS                | TCP       | DISABLED        | ENABLED          |
 | 8745  | Input                     | attested-tls-proxy              | Host                 | TCP       | ENABLED         | ENABLED          |
@@ -305,6 +308,14 @@ https://backruns.tee-searcher.flashbots.net
 ### Searching on BuilderNet's Bottom of Block
 
 BuilderNet serves both the state diff stream and bundle submission over the same HTTPS endpoint (`rpc.buildernet.org`). Because they share one endpoint, both are reachable only in **production mode** — unlike the Flashbots bundle RPC, which is always on.
+
+The host resolves `rpc.buildernet.org` and the three regional
+`direct-{ap,eu,us}.buildernet.org` names through Cloudflare DNS-over-TLS and
+requires DNSSEC-authenticated responses before atomically updating the production
+IP allowlist. If a refresh fails, the previous successfully validated address set
+is retained as the last-known-good set on the encrypted persistent volume and is
+restored after reboot if needed. DNS names with additional prefixes or subdomains
+are not included in the allowlist.
 
 **<u>Subscribing to BuilderNet's State Diff Stream</u>**
 

--- a/tests/integration/test_flashbox_l1.py
+++ b/tests/integration/test_flashbox_l1.py
@@ -13,6 +13,7 @@ So the order here is load-bearing: attestation is only reachable AFTER
 the key push, and a failure cascades into the tests below it by design.
 """
 
+import ipaddress
 import json
 import os
 import subprocess
@@ -189,6 +190,39 @@ def test_ssh_in(vm_ip, tmp_path, known_hosts_file, containersh):
             flush=True,
         )
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.dependency(depends=["container_ssh"])
+def test_buildernet_dns_allowlist(containersh):
+    resolv_conf = containersh("cat /etc/resolv.conf")
+    assert resolv_conf.returncode == 0, resolv_conf.stdout + resolv_conf.stderr
+    nameservers = [
+        line.split()[1]
+        for line in resolv_conf.stdout.splitlines()
+        if line.split()[:1] == ["nameserver"]
+    ]
+    assert nameservers == ["169.254.2.3"], resolv_conf.stdout
+
+    for name in (
+        "rpc.buildernet.org",
+        "direct-ap.buildernet.org",
+        "direct-eu.buildernet.org",
+        "direct-us.buildernet.org",
+    ):
+        result = containersh(f"getent ahostsv4 {name}")
+        assert result.returncode == 0, result.stdout + result.stderr
+        addresses = {line.split()[0] for line in result.stdout.splitlines()}
+        assert addresses, f"{name} returned no IPv4 addresses"
+        assert all(
+            ipaddress.ip_address(address).is_global for address in addresses
+        ), f"{name} returned non-global addresses: {sorted(addresses)}"
+
+    # Both an unrelated name and a prefixed lookalike must hit the terminal
+    # NXDOMAIN rule. The latter guards against accidentally changing the exact
+    # QName matcher into suffix matching.
+    for name in ("example.com", "leak.rpc.buildernet.org"):
+        denied = containersh(f"getent ahostsv4 {name}")
+        assert denied.returncode != 0, denied.stdout
 
 
 @pytest.mark.dependency(depends=["container_ssh"])


### PR DESCRIPTION
## Summary
This change replaces the static BuilderNet IP mappings in Flashbox L1 images with restricted, dynamic DNS resolution.

Searchers can resolve only these exact names:
- rpc.buildernet.org
- direct-ap.buildernet.org
- direct-eu.buildernet.org
- direct-us.buildernet.org

No prefixes or subdomains are accepted. For example, leak.rpc.buildernet.org is rejected.

## How it works
- A small dnsdist service runs on the host.
- The searcher container receives a single DNS server through its pasta network.
- Exact A queries for the four allowed names are forwarded to Cloudflare over DNS-over-TLS.
- Exact AAAA queries return an empty response because IPv6 is disabled.
- Every other name, record type, malformed query, or query containing an EDNS payload returns NXDOMAIN locally.
- Direct access from the sandbox to external DNS servers remains blocked in production.

A timer resolves the four names every minute and verifies that Cloudflare returned DNSSEC-authenticated, direct A records. CNAME responses and private or special-purpose IP addresses are rejected.

After validation, the resolved addresses atomically replace the buildernet_v4 nftables set. Production firewall rules allow TCP/443 only to addresses in that set.

## Last-known-good behavior
If DNS resolution, DNSSEC validation, or the firewall update fails, the existing address set remains unchanged.
The last successfully validated set is stored on the encrypted persistent volume and restored after reboot. This favors availability while accepting delayed removal of an old address.
When an address is removed successfully, existing conntrack entries to that address are deleted so an established connection cannot bypass the updated allowlist.

## Security boundaries
- The attacker-facing DNS parser has no firewall administration capability.
- Only the _dnsdist user may connect to 1.1.1.1:853.
- All other new connections from _dnsdist are explicitly dropped.
- The firewall updater has fixed inputs and is the only component given CAP_NET_ADMIN.
- Production mode is refused unless the persisted state and live nftables set match.
- Static BuilderNet entries have been removed from the container’s /etc/hosts.